### PR TITLE
Implement long press for fav, random on short press (X button) in game list view

### DIFF
--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -21,6 +21,47 @@
 #include "SaveStateRepository.h"
 #include "guis/GuiSaveState.h"
 
+#ifdef _ENABLEEMUELEC
+constexpr auto BUTTON_HOLD_TIME = 1000; // ms
+
+
+auto MultiFunctionButton::input(bool isPressed) -> Action
+{
+	const auto wasPressed = mIsPressed;
+	mIsPressed = isPressed;
+
+	if (isPressed && !wasPressed)
+	{
+		mTimeHoldingButton = 0;
+		mLongPressHasFired = false;
+	}
+	else if (!isPressed && wasPressed)
+	{
+		if (!mLongPressHasFired)
+		{
+			return Action::shortPress;
+		}
+	}
+
+	return Action::none;
+}
+
+auto MultiFunctionButton::update(int deltaTime) -> Action
+{
+	if (mIsPressed && !mLongPressHasFired)
+	{
+		mTimeHoldingButton += deltaTime;
+		if (mTimeHoldingButton >= BUTTON_HOLD_TIME)
+		{
+			mLongPressHasFired = true;
+			return Action::longPress;
+		}
+	}
+
+	return Action::none;
+}
+#endif
+
 ISimpleGameListView::ISimpleGameListView(Window* window, FolderData* root, bool temporary) : IGameListView(window, root),
 	mHeaderText(window), mHeaderImage(window), mBackground(window), mFolderPath(window), mOnExitPopup(nullptr)
 {
@@ -125,8 +166,36 @@ FolderData*		ISimpleGameListView::getCurrentFolder()
 	return nullptr;
 }
 
+#ifdef _ENABLEEMUELEC
+void ISimpleGameListView::update(const int deltaTime)
+{
+	GuiComponent::update(deltaTime);
+
+	const auto action = mFavOrRandomButton.update(deltaTime);
+	if (action == MultiFunctionButton::Action::longPress)
+	{
+		if (auto cursor = getCursor())
+		{
+			CollectionSystemManager::get()->toggleGameInCollection(cursor, "Favorites");
+		}
+	}
+}
+#endif
+
 bool ISimpleGameListView::input(InputConfig* config, Input input)
 {
+#ifdef _ENABLEEMUELEC
+		if (config->isMappedTo("x", input))
+		{
+			const auto action = mFavOrRandomButton.input(input.value != 0);
+			if (action == MultiFunctionButton::Action::shortPress)
+			{
+				moveToRandomGame();
+				return true;
+			}
+		}
+#endif
+
 	if (input.value != 0)
 	{
 		if (config->isMappedTo("l3", input))
@@ -256,11 +325,6 @@ bool ISimpleGameListView::input(InputConfig* config, Input input)
 
 			return true;
 		}
-		else if (config->isMappedTo("x", input))
-		{ 
-			moveToRandomGame();
-			return true;            
-        }
         else if (config->isMappedTo("RightThumb", input))
 		{ 
             FileData* cursor = getCursor();

--- a/es-app/src/views/gamelist/ISimpleGameListView.h
+++ b/es-app/src/views/gamelist/ISimpleGameListView.h
@@ -8,6 +8,27 @@
 #include <stack>
 #include <set>
 
+#ifdef _ENABLEEMUELEC
+class MultiFunctionButton
+{
+public:
+	enum class Action
+	{
+		none,
+		shortPress,
+		longPress
+	};
+
+	Action input(bool isPressed);
+	Action update(int deltaTime);
+
+private:
+	int mTimeHoldingButton = 0;
+	bool mIsPressed = false;
+	bool mLongPressHasFired = false;
+};
+#endif
+
 class ISimpleGameListView : public IGameListView
 {
 public:
@@ -26,6 +47,10 @@ public:
 	virtual void setCursor(FileData*) = 0;
 	virtual int getCursorIndex() =0; // batocera
 	virtual void setCursorIndex(int index) =0; // batocera
+
+#ifdef _ENABLEEMUELEC
+	virtual void update(int deltaTime) override;
+#endif
 
 	virtual bool input(InputConfig* config, Input input) override;
 	virtual void launch(FileData* game) = 0;
@@ -62,6 +87,9 @@ protected:
 	std::vector<GuiComponent*> mThemeExtras;
 
 	std::stack<FileData*> mCursorStack;
+#ifdef _ENABLEEMUELEC
+	MultiFunctionButton mFavOrRandomButton;
+#endif
 };
 
 #endif // ES_APP_VIEWS_GAME_LIST_ISIMPLE_GAME_LIST_VIEW_H


### PR DESCRIPTION
This makes it so that the X button can be used for 2 purposes: a normal button press chooses a random game like before, but holding the button for at least a second toggles the current game's favorite status instead. One side effect of this change is that the random functionality is now triggered on button up instead of button down, which might in theory feel a little less snappy than before - it seemed fine to me when testing on my OGA, though.

I did not yet adapt the legend/help text, as I wasn't sure what it should say. "Random/Favorite"?

If we'd like to have this same behavior in other types of views besides `ISimpleGameListView`, it would be pretty easy to add as well.