### PR TITLE
Dev sort names fix, falls back to name if sortname not in both files.

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -245,8 +245,7 @@ const std::string FileData::getSortName() const
 #ifdef _ENABLEEMUELEC
 const std::string FileData::getSortNameCmp() const
 {
-	std::string sortName = mMetadata.get("sortname");
-	return sortName;
+	return mMetadata.get("sortname");
 }
 #endif
 

--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -242,6 +242,14 @@ const std::string FileData::getSortName() const
 		return sortName;
 }
 
+#ifdef _ENABLEEMUELEC
+const std::string FileData::getSortNameCmp() const
+{
+	std::string sortName = mMetadata.get("sortname");
+	return sortName;
+}
+#endif
+
 const std::string FileData::getVideoPath()
 {
 	std::string video = getMetadata(MetaDataId::Video);

--- a/es-app/src/FileData.h
+++ b/es-app/src/FileData.h
@@ -64,7 +64,10 @@ public:
 
 	virtual const std::string& getName();
 	virtual const std::string getSortName() const;
-
+#ifdef _ENABLEEMUELEC
+	virtual const std::string getSortNameCmp() const;
+#endif
+	 
 	inline FileType getType() const { return mType; }
 	
 	inline FolderData* getParent() const { return mParent; }

--- a/es-app/src/FileSorts.cpp
+++ b/es-app/src/FileSorts.cpp
@@ -75,11 +75,21 @@ namespace FileSorts
 	{
 		if (file1->getType() != file2->getType())
 			return file1->getType() == FOLDER;
-
-		// we compare the actual metadata name, as collection files have the system appended which messes up the order
-		std::string name1 = file1->getSortName();
-		std::string name2 = file2->getSortName();
+		
+#ifdef _ENABLEEMUELEC
+		std::string name1 = file1->getSortNameCmp();
+		std::string name2 = file2->getSortNameCmp();
+		if (name1.empty() || name2.empty()) {
+			name1 = file1->getName();
+			name2 = file2->getName();
+		}
 		return Utils::String::compareIgnoreCase(name1, name2) < 0;
+#else
+ 		// we compare the actual metadata name, as collection files have the system appended which messes up the order
+ 		std::string name1 = file1->getSortName();
+ 		std::string name2 = file2->getSortName();
+		return Utils::String::compareIgnoreCase(name1, name2) < 0;
+#endif		
 	}
 
 	bool compareRating(const FileData* file1, const FileData* file2)


### PR DESCRIPTION
Fix to issue:
https://github.com/EmuELEC/EmuELEC/issues/720

If one of the files doesnt have a sortname then it falls back to checking by game name. This is too ensure backward compatibility for gamelists that do not have sortname (which some do not have).
