### PR TITLE
Ee joybtncfg3

### DIFF
--- a/es-app/src/CustomFeatures.cpp
+++ b/es-app/src/CustomFeatures.cpp
@@ -54,7 +54,8 @@ EmulatorFeatures::Features EmulatorFeatures::parseFeatures(const std::string fea
 		if (trim == "autocontrollers") ret = ret | EmulatorFeatures::Features::autocontrollers;
 #ifdef _ENABLEEMUELEC
 		if (trim == "vertical") ret = ret | EmulatorFeatures::Features::vertical;
-		if (trim == "nativevideo") ret = ret | EmulatorFeatures::Features::nativevideo;		
+		if (trim == "nativevideo") ret = ret | EmulatorFeatures::Features::nativevideo;
+		if (trim == "joybtnremap") ret = ret | EmulatorFeatures::Features::joybtnremap;
 #endif
 	}
 

--- a/es-app/src/CustomFeatures.h
+++ b/es-app/src/CustomFeatures.h
@@ -87,8 +87,9 @@ public:
 		cheevos = 131072,
 		autocontrollers = 262144,
 #ifdef _ENABLEEMUELEC
-        vertical = 524288,
+    vertical = 524288,
 		nativevideo = 1048576,
+		joybtnremap = 2097152,
 #endif
 		all = 0x0FFFFFFF
 	};

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4282,26 +4282,22 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
 			_("YES"), [mWindow, del_choice, prefixName, arr_joy_btn_names, btn_choice, iIndexes]
 			{
-				std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
+				std::vector<std::string> tNames(arr_joy_btn_names);
 				int delIndex = (del_choice->getSelectedIndex()-1);
-
-				std::string tName = del_choice->getSelectedName();
-
-				l_arr_joy_btn_names.erase(l_arr_joy_btn_names.begin() + delIndex);
-// TODO indexes are screwing up.
+				tNames.erase(tNames.begin() + delIndex);
 
 				std::vector<int> tIndexes(iIndexes);
 				int remapIndex = tIndexes[delIndex];
 				tIndexes.erase(tIndexes.begin() + delIndex);
 
-				std::string remapNames = "";
-				for(int i=0; i < l_arr_joy_btn_names.size(); ++i)
+				std::string sRemapNames = "";
+				for(int i=0; i < tNames.size(); ++i)
 				{
 					if (i > 0)
-						remapNames += ",";
-					remapNames += l_arr_joy_btn_names[i];
+						sRemapNames += ",";
+					sRemapNames += tNames[i];
 				}
-				SystemConf::getInstance()->set(prefixName + ".joy_btn_names", remapNames);
+				SystemConf::getInstance()->set(prefixName + ".joy_btn_names", sRemapNames);
 				SystemConf::getInstance()->set(prefixName + ".joy_btn_order"+std::to_string(remapIndex), "");
 
 				std::string sIndexes = "";
@@ -4315,6 +4311,8 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 
 				SystemConf::getInstance()->saveSystemConf();
 				
+				std::string tName = del_choice->getSelectedName();
+
 				bool btn_match = del_choice->getSelectedIndex() == btn_choice->getSelectedIndex();
 				del_choice->selectFirstItem();
 				del_choice->remove(tName);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4105,7 +4105,7 @@ void GuiMenu::createBtnJoyCfg(Window *mWindow, std::string title)
 		// save to config
 	};
 
-	row.makeAcceptInputHandler([mTextRemap, updateVal]
+	row.makeAcceptInputHandler([mWindow, mTextRemap, updateVal]
 	{
 		if (Settings::getInstance()->getBool("UseOSK"))
 			mWindow->pushGui(new GuiTextEditPopupKeyboard(mWindow, _("CREATE BUTTON REMAP NAME"), mTextRemap->getValue(), updateVal, false));
@@ -4113,7 +4113,7 @@ void GuiMenu::createBtnJoyCfg(Window *mWindow, std::string title)
 			mWindow->pushGui(new GuiTextEditPopup(mWindow, _("CREATE BUTTON REMAP NAME"), mTextRemap->getValue(), updateVal, false));
 	});
 
-	addRow(row);
+	systemConfiguration->addRow(row);
 }
 #endif
 
@@ -4208,13 +4208,8 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		systemConfiguration->addSaveFunc([configName, joyBtn_choice] {
 				SystemConf::getInstance()->set(configName + ".joy_btn_cfg", joyBtn_choice->getSelected());
 				SystemConf::getInstance()->saveSystemConf();
-				
-				
-		auto joyBtn_create = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
-		systemConfiguration->addWithLabel(_("CREATE BUTTON REMAP"), joyBtn_choice);
 		});
-		
-		
+
 		addCreateButtonRemapToMenu(mWindow, title);
 	}
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4183,7 +4183,7 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfigura
 		}
 		
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO CREATE THE REMAP?"),
-			_("YES"), [mWindow, remap_choice, del_choice, btn_choice, remapCount, prefixName, remapName, remapNames, btnCount]
+			_("YES"), [mWindow, remap_choice, del_choice, btn_choice, remapCount, prefixName, remapName, remapNames]
 		{
 			int count = remapCount+1;
 
@@ -4191,8 +4191,8 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfigura
 			SystemConf::getInstance()->set(prefixName + ".joy_btn_names", names);
 
 			std::string joyRemap = "";
-			for(int i=0; i < btnCount; ++i)
-			{
+			int size = remap_choice[0]->size();
+			for(int i=0; i < size; ++i) {
 				if (i > 0)
 					joyRemap += " ";
 				joyRemap += remap_choice[i]->getSelected();
@@ -4299,7 +4299,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 					sRemapNames += tNames[i];
 				}
 				SystemConf::getInstance()->set(prefixName + ".joy_btn_names", sRemapNames);
-				SystemConf::getInstance()->set(prefixName + ".joy_btn_order"+std::to_string(remapIndex), "");
+				//SystemConf::getInstance()->set(prefixName + ".joy_btn_order"+std::to_string(remapIndex), "");
 
 				std::string sIndexes = "";
 				for(i=0; i < tIndexes.size(); ++i)
@@ -5043,7 +5043,6 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 
 	int index = 0;
 	joy_btn_cfg->add("auto", "0", cfgIndex == index);
-	index++;
 	for (auto it = joy_btn_recs.cbegin(); it != joy_btn_recs.cend(); it++) {
 		joy_btn_cfg->add(*it, std::to_string(joy_btn_indexes[index]), cfgIndex == joy_btn_indexes[index]);
 		index++;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4285,7 +4285,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				std::string tName = l_arr_joy_btn_names[delIndex];
 
 				l_arr_joy_btn_names.erase(l_arr_joy_btn_names.begin() + delIndex);
-
+// TODO indexes are screwing up.
 				std::string sIndexes = SystemConf::getInstance()->get(prefixName + ".joy_btn_indexes");
 				std::vector<int> iIndexes = int_explode(sIndexes);	
 				int remapIndex = iIndexes[delIndex];
@@ -4306,7 +4306,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				{
 					if (i > 0)
 						sIndexes += ",";
-					sIndexes += iIndexes[i];
+					sIndexes += std::to_string(iIndexes[i]);
 				}
 				SystemConf::getInstance()->set(prefixName + ".joy_btn_indexes", sIndexes);
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4255,6 +4255,11 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		}		
 		SystemConf::getInstance()->set(prefixName + ".joy_btn_names", remapNames);
 		SystemConf::getInstance()->set(prefixName + ".joy_btn_order"+std::to_string(index), "");
+		
+		int count = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_map_count").c_str());
+		if (count > 0)
+			SystemConf::getInstance()->set(prefixName + ".joy_btn_map_count", std::to_string(--count));
+		
 		SystemConf::getInstance()->saveSystemConf();
 	});
 }

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4163,9 +4163,12 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	}
 
 	//std::string tEmulator = (currentEmulator == "auto") ? systemData->getEmulator(true) : currentEmulator;
-	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::joybtnremap))
+	std::string tEmulator = fileData != nullptr ? fileData->getEmulator(true) : systemData->getEmulator(true);
+	if (tEmulator == "auto")
+		tEmulator = systemData->getEmulator(true);
+	if (!tEmulator.empty() && systemData->isFeatureSupported(tEmulator, currentCore, EmulatorFeatures::joybtnremap))
 	{
-		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, currentEmulator);
+		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
 		systemConfiguration->addWithLabel(_("JOY BUTTON CFG"), joyBtn_choice);
 		systemConfiguration->addSaveFunc([configName, joyBtn_choice] {
 			if (!joyBtn_choice->getSelected().empty()) {
@@ -4757,8 +4760,8 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 
 	int remapCount = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_count").c_str());
 
-	if (remapCount == 0) {
-		
+	if (prefixName == "auto" || prefixName.empty() || remapCount == 0) {
+		joy_btn_cfg->add("auto", "0", true);
 		return joy_btn_cfg;
 	}
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4126,7 +4126,7 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *mSystemConfigur
 		
 		remap_choice.push_back(createJoyBtnRemapOptionList(mWindow, prefixName, index));
 		mSystemConfiguration->addWithLabel(_("JOY BUTTON ")+std::to_string(index), remap_choice[index]);
-		mSystemConfiguration->addSaveFunc([mWindow, configName, remap_choice, remapCount, prefixName, remapName, index] {
+		mSystemConfiguration->addSaveFunc([mWindow, remap_choice, remapCount, prefixName, remapName, index] {
 
 			for(int i=0; i < remapCount; ++i)
 			{

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4086,6 +4086,15 @@ void GuiMenu::popGameConfigurationGui(Window* mWindow, FileData* fileData)
 #ifdef _ENABLEEMUELEC
 void GuiMenu::createBtnJoyCfg(Window *mWindow, GuiSettings *mSystemConfiguration, std::string prefixName)
 {
+	InputConfig* inputCfg = nullptr;
+	if (InputManager::getInstance()->getNumJoysticks() > 0) {
+		auto configList = InputManager::getInstance()->getInputConfigs();
+		inputCfg = configList[0];
+	}
+	
+	if (inputCfg == nullptr)
+		return;
+	
 	auto theme = ThemeData::getMenuTheme();
 
 	ComponentListRow row;
@@ -4093,14 +4102,18 @@ void GuiMenu::createBtnJoyCfg(Window *mWindow, GuiSettings *mSystemConfiguration
 	auto text = std::make_shared<TextComponent>(mWindow, _("CREATE BUTTON REMAP"), theme->Text.font, theme->Text.color);
 	row.addElement(text, true);
 
-	auto updateVal = [text,prefixName](const std::string& newVal)
+
+	auto updateVal = [text, prefixName, inputCfg](const std::string& newVal)
 	{
 		int remapCount = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_count").c_str());
 		SystemConf::getInstance()->set(prefixName + ".joy_btn_count", std::to_string(++remapCount));
 		SystemConf::getInstance()->set(prefixName + ".joy_btn_name" + std::to_string(remapCount), newVal);
 
-		
-		// save to config
+		std::function<void()> okCallback = [] {
+			
+		};
+
+		mWindow->pushGui(new GuiInputConfig(mWindow, inputCfg, true, okCallback));
 	};
 
 	row.makeAcceptInputHandler([mWindow, text, updateVal]

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4293,7 +4293,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		i++;
 	}
 
-	systemConfiguration->addSaveFunc([mWindow, btn_choice, del_choice, prefixName, arr_btn_names, iIndexes] {
+	del_choice->setSelectedChangedCallback([mWindow, btn_choice, del_choice, prefixName, arr_btn_names, iIndexes](std::string s) {
 		int index = del_choice->getSelectedIndex();
 		if (index == 0)
 			return;
@@ -4301,6 +4301,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
 			_("YES"), [mWindow, btn_choice, del_choice, prefixName, arr_btn_names, iIndexes, delIndex]
 			{
+				SystemConf::getInstance()->set(prefixName + ".value", s);
 				std::vector<std::string> tNames(arr_btn_names);
 				int delCfgIndex = (delIndex-1);
 				tNames.erase(tNames.begin() + delIndex);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4162,7 +4162,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		});
 	}
 
-	std::string tEmulator = (systemData->getEmulator().empty() ? currentEmulator : systemData->getEmulator())
+	std::string tEmulator = (systemData->getEmulator().empty() ? currentEmulator : systemData->getEmulator());
 	if (systemData->isFeatureSupported(tEmulator, currentCore, EmulatorFeatures::joybtnremap))
 	{
 		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4272,7 +4272,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				SystemConf::getInstance()->saveSystemConf();			
 			}, 
 			_("NO"), nullptr));
-	}());
+	});
 	
 	systemConfiguration->addWithLabel(_("DELETE REMAP"), deleteOption, delFunc);	
 	

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4210,7 +4210,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 				SystemConf::getInstance()->saveSystemConf();
 		});
 
-		addCreateButtonRemapToMenu(mWindow, title);
+		createBtnJoyCfg(mWindow, title);
 	}
 
 #endif 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4237,30 +4237,35 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 	systemConfiguration->addWithLabel(_("DELETE REMAP"), deleteOption);	
 	
 	systemConfiguration->addSaveFunc([mWindow, deleteOption, prefixName, arr_joy_btn_names] {
-		std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
-		int index = atoi(deleteOption->getSelected().c_str());
-		if (index == -1)
-			return;
+		mWindow->pushGui(new GuiMsgBox(window, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
+			_("YES"), [mWindow, deleteOption, prefixName, arr_joy_btn_names]
+			{
+				std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
+				int index = atoi(deleteOption->getSelected().c_str());
+				if (index == -1)
+					return;
 
-		l_arr_joy_btn_names.erase(l_arr_joy_btn_names.begin() + index);
+				l_arr_joy_btn_names.erase(l_arr_joy_btn_names.begin() + index);
 
-		index++;
+				index++;
 
-		std::string remapNames = "";
-		for(int i=0; i < l_arr_joy_btn_names.size(); ++i)
-		{
-			if (i > 0)
-				remapNames += ",";
-			remapNames += l_arr_joy_btn_names[i];
-		}		
-		SystemConf::getInstance()->set(prefixName + ".joy_btn_names", remapNames);
-		SystemConf::getInstance()->set(prefixName + ".joy_btn_order"+std::to_string(index), "");
-		
-		int count = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_map_count").c_str());
-		if (count > 0)
-			SystemConf::getInstance()->set(prefixName + ".joy_btn_map_count", std::to_string(--count));
-		
-		SystemConf::getInstance()->saveSystemConf();
+				std::string remapNames = "";
+				for(int i=0; i < l_arr_joy_btn_names.size(); ++i)
+				{
+					if (i > 0)
+						remapNames += ",";
+					remapNames += l_arr_joy_btn_names[i];
+				}		
+				SystemConf::getInstance()->set(prefixName + ".joy_btn_names", remapNames);
+				SystemConf::getInstance()->set(prefixName + ".joy_btn_order"+std::to_string(index), "");
+				
+				int count = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_map_count").c_str());
+				if (count > 0)
+					SystemConf::getInstance()->set(prefixName + ".joy_btn_map_count", std::to_string(--count));
+				
+				SystemConf::getInstance()->saveSystemConf();			
+			}, 
+			_("NO"), nullptr));
 	});
 }
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -5037,8 +5037,12 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 		return joy_btn_cfg;
 	}
 
-	int cfgIndex = atoi(joy_btn_cfg->getSelected().c_str());
-	//int cfgIndex = atoi(SystemConf::getInstance()->get(configname + ".joy_btn_cfg").c_str());
+	int cfgIndex = 0;
+	if (!joy_btn_cfg->getSelected().empty())
+		cfgIndex = atoi(joy_btn_cfg->getSelected().c_str());
+	else
+		cfgIndex = atoi(SystemConf::getInstance()->get(configname + ".joy_btn_cfg").c_str());
+	
 	if (cfgIndex > joy_btn_recs.size())
 		cfgIndex = 0;
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4158,7 +4158,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		systemConfiguration->addWithLabel(_("NATIVE VIDEO"), videoNativeResolutionMode_choice);
 		systemConfiguration->addSaveFunc([configName, videoNativeResolutionMode_choice] {
 			SystemConf::getInstance()->set(configName + ".nativevideo", videoNativeResolutionMode_choice->getSelected());
-			SystemConf::getInstance()->saveSystemConf();
+			//SystemConf::getInstance()->saveSystemConf();
 		});
 	}
 
@@ -4173,7 +4173,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		systemConfiguration->addSaveFunc([configName, joyBtn_choice] {
 			if (!joyBtn_choice->getSelected().empty()) {
 				SystemConf::getInstance()->set(configName + ".joy_btn_cfg", joyBtn_choice->getSelected());
-				SystemConf::getInstance()->saveSystemConf();
+				//SystemConf::getInstance()->saveSystemConf();
 			}
 		});
 	}
@@ -4774,8 +4774,8 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 
 	int cfgIndex = atoi(SystemConf::getInstance()->get(configname + ".joy_btn_cfg").c_str());
 
-	int index = 0;
 	joy_btn_cfg->add("auto", "0", cfgIndex == index);
+	int index = 1;
 	for (auto it = joy_btn_recs.cbegin(); it != joy_btn_recs.cend(); it++) {
 		joy_btn_cfg->add(*it, std::to_string(index), cfgIndex == index);
 		index++;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4157,8 +4157,10 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		auto videoNativeResolutionMode_choice = createNativeVideoResolutionModeOptionList(mWindow, configName);
 		systemConfiguration->addWithLabel(_("NATIVE VIDEO"), videoNativeResolutionMode_choice);
 		systemConfiguration->addSaveFunc([configName, videoNativeResolutionMode_choice] {
-			SystemConf::getInstance()->set(configName + ".nativevideo", videoNativeResolutionMode_choice->getSelected());
-			//SystemConf::getInstance()->saveSystemConf();
+			if (videoNativeResolutionMode_choice->changed()) {
+				SystemConf::getInstance()->set(configName + ".nativevideo", videoNativeResolutionMode_choice->getSelected());
+				SystemConf::getInstance()->saveSystemConf();
+			}
 		});
 	}
 
@@ -4171,9 +4173,9 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
 		systemConfiguration->addWithLabel(_("JOY BUTTON CFG"), joyBtn_choice);
 		systemConfiguration->addSaveFunc([configName, joyBtn_choice] {
-			if (!joyBtn_choice->getSelected().empty()) {
+			if (joyBtn_choice->changed()) {
 				SystemConf::getInstance()->set(configName + ".joy_btn_cfg", joyBtn_choice->getSelected());
-				//SystemConf::getInstance()->saveSystemConf();
+				SystemConf::getInstance()->saveSystemConf();
 			}
 		});
 	}

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4289,7 +4289,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		i++;
 	}
 
-	del_choice->setSelectedChangedCallback([&mWindow, &btn_choice, &del_choice, prefixName, remap_names, iIndexes](std::string s) {		
+	del_choice->setSelectedChangedCallback([&mWindow, &btn_choice, &del_choice, prefixName](std::string s) {		
 		int delIndex = del_choice->getSelectedIndex();
 		if (delIndex <= 0)
 			return;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4754,8 +4754,8 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 	
 	std::vector<std::pair<std::string,std::string>> joy_btn_recs;
 	for (int i=0; i < index; ++i) {
-		std::string name = SystemConf::getInstance()->get(emulator + ".joy_btn_name" + std::tostring(i));
-		std::string val = SystemConf::getInstance()->get(emulator + ".joy_btn_order" + std::tostring(i));
+		std::string name = SystemConf::getInstance()->get(emulator + ".joy_btn_name" + std::to_string(i));
+		std::string val = SystemConf::getInstance()->get(emulator + ".joy_btn_order" + std::to_string(i));
 		joy_btn_recs.push_back( std::make_pair(name,val));
 	}
 	

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4130,7 +4130,6 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnRemapOpti
 
 	std::vector<std::string> arr_joy_btn(explode(joy_btns));
 
-	joy_btn_cfg->add("NONE", "-1", false);
 	int index = 0;
 	for (auto it = arr_joy_btn.cbegin(); it != arr_joy_btn.cend(); it++) {
 		joy_btn_cfg->add(*it, std::to_string(index), btnIndex == index);
@@ -4199,14 +4198,14 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfigura
 			std::string names = remapNames+","+remapName;
 			SystemConf::getInstance()->set(prefixName + ".joy_btn_names", names);
 
-			std::string joyRemap = "";
+			std::string sRemap = "";
 			for(int i=0; i < btnCount; ++i) {
 				if (i > 0)
-					joyRemap += " ";
-				joyRemap += remap_choice[i]->getSelected();
+					sRemap += " ";
+				sRemap += remap_choice[i]->getSelected();
 			}
 			std::string sNewIndex = std::to_string(newIndex);
-			SystemConf::getInstance()->set(prefixName + ".joy_btn_order" + sNewIndex, joyRemap);
+			SystemConf::getInstance()->set(prefixName + ".joy_btn_order" + sNewIndex, sRemap);
 
 			std::string indexes = SystemConf::getInstance()->get(prefixName + ".joy_btn_indexes");
 			SystemConf::getInstance()->set(prefixName + ".joy_btn_indexes", indexes+","+sNewIndex);
@@ -4304,11 +4303,11 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				
 				std::vector<std::string> tNames(arr_btn_names);
 				int delCfgIndex = (delIndex-1);
-				tNames.erase(tNames.begin() + delIndex);
+				tNames.erase(tNames.cbegin() + delIndex);
 
 				std::vector<int> tIndexes(iIndexes);
 				int remapIndex = tIndexes[delIndex];
-				tIndexes.erase(tIndexes.begin() + delIndex);
+				tIndexes.erase(tIndexes.cbegin() + delIndex);
 
 				std::string sRemapNames = "";
 				int i;
@@ -4332,19 +4331,18 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 
 				SystemConf::getInstance()->saveSystemConf();
 
-				std::string tName = del_choice->getSelectedName();
-
 				int old_del_choice_val = delIndex;
+				del_choice->selectNone();
+				del_choice->removeIndex(delIndex);
 				del_choice->selectFirstItem();
-				del_choice->remove(tName);
 
-				int btn_index = btn_choice->getSelectedIndex();
-				if (btn_index == old_del_choice_val || btn_index >= del_choice->size())
-					btn_index = 0;
+				int btnIndex = btn_choice->getSelectedIndex();
+				if (btnIndex == old_del_choice_val || btnIndex >= del_choice->size())
+					btnIndex = 0;
 
 				btn_choice->selectNone();
-				btn_choice->remove(tName);
-				btn_choice->selectIndex(btn_index);
+				btn_choice->removeIndex(delIndex);
+				btn_choice->selectIndex(btnIndex);
 			},
 			_("NO"), nullptr));
 	});
@@ -4454,7 +4452,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 			systemConfiguration->addWithLabel(_("BUTTON REMAP"), btn_choice);
 			std::string prefixName = tEmulator;
 			systemConfiguration->addSaveFunc([configName, btn_choice, prefixName] {
-				if (btn_choice->getSelectedIndex() >= 0)
+				if (btn_choice->getSelectedIndex() > 0)
 				{
 					std::string btnIndexes = SystemConf::getInstance()->get(prefixName + ".joy_btn_indexes");
 					std::vector<int> btn_indexes(int_explode(btnIndexes));
@@ -5052,8 +5050,8 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 {
 	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
 
-	std::string joyBtnNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_names");
-	std::vector<std::string> joy_btn_recs(explode(joyBtnNames));
+	std::string btnNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_names");
+	std::vector<std::string> btn_names(explode(btnNames));
 
 	int remapCount = joy_btn_recs.size();
 
@@ -5063,13 +5061,14 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 	}
 
 	int cfgIndex = atoi(SystemConf::getInstance()->get(configname + ".joy_btn_cfg").c_str());
-	if (cfgIndex > joy_btn_recs.size())
+	if (cfgIndex > btn_names.size())
 		cfgIndex = 0;
 
 	int i = 1;
 	joy_btn_cfg->add("auto", "0", cfgIndex == 0);
-	for (auto it = joy_btn_recs.cbegin(); it != joy_btn_recs.cend(); it++) {
-		joy_btn_cfg->add(*it, std::to_string(i), cfgIndex == i++);
+	for (auto it = btn_names.cbegin(); it != btn_names.cend(); it++) {
+		joy_btn_cfg->add(*it, std::to_string(i), cfgIndex == i);
+		i++;
 	}
 	return joy_btn_cfg;
 }

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4339,7 +4339,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 
 				int btn_index = btn_choice->getSelectedIndex();
 
-				if (btn_index == old_del_choice_val || btn_index >= (btn_size()-1))
+				if (btn_index == old_del_choice_val || btn_index >= (btn_choice->size()-1))
 					btn_choice->selectFirstItem();
 				btn_choice->remove(tName);
 			},

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4287,7 +4287,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 
 				std::string sIndexes = SystemConf::getInstance()->get(prefixName + ".joy_btn_indexes");
 				std::vector<int> iIndexes = int_explode(sIndexes);	
-				int remapIndex = iIndexes[index];
+				int remapIndex = iIndexes[delIndex];
 				iIndexes.erase(iIndexes.begin() + delIndex);
 
 				std::string remapNames = "";

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4240,7 +4240,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		index++;
 	}
 
-	std::function<void()> delFunc = [&] {
+	auto delFunc = [&] {
 		int index = atoi(deleteOption->getSelected().c_str());
 		if (index == -1)
 			return;
@@ -4276,7 +4276,8 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 	
 	systemConfiguration->addWithLabel(_("DELETE REMAP"), deleteOption, delFunc, "", false);	
 	
-	
+	deleteOption->setSelectedChangedCallback(delFunc);
+
 	/*systemConfiguration->addSaveFunc([mWindow, deleteOption, prefixName, arr_joy_btn_names] {
 		int index = atoi(deleteOption->getSelected().c_str());
 		if (index == -1)

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4092,7 +4092,7 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, std::string prefixName)
 
 void GuiMenu::createBtnJoyCfgName(Window *mWindow, std::string prefixName)
 {
-	auto updateVal = [mWindow, text, prefixName, inputCfg](const std::string& newVal)
+	auto updateVal = [mWindow, prefixName](const std::string& newVal)
 	{
 		int remapCount = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_count").c_str());
 		SystemConf::getInstance()->set(prefixName + ".joy_btn_count", std::to_string(++remapCount));
@@ -4197,9 +4197,9 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	{
 		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
 		systemConfiguration->addWithLabel(_("JOY BUTTON CFG"), joyBtn_choice);
-		systemConfiguration->addSaveFunc([configName, joyBtn_choice] {
+		systemConfiguration->addSaveFunc([mWindow, configName, joyBtn_choice, tEmulator] {
 			if (joyBtn_choice->getSelected() == std::to_string(joyBtn_choice->size()-1)) {
-				GuiMenu::createBtnJoyCfg(mWindow, tEmulator);		
+				GuiMenu::createBtnJoyCfgName(mWindow, tEmulator);		
 			}
 			else {
 				SystemConf::getInstance()->set(configName + ".joy_btn_cfg", joyBtn_choice->getSelected());
@@ -4814,7 +4814,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 		joy_btn_cfg->add(*it, std::to_string(index), cfgIndex == index);
 		index++;
 	}
-	joy_btn_cfg->add("add new", remapCount+2, cfgIndex == index);
+	joy_btn_cfg->add("add new", std::to_string(joy_btn_cfg.size()-1), cfgIndex == index);
 	return joy_btn_cfg;
 }
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4246,7 +4246,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 			return;
 		
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
-			_("YES"), [&, mWindow, deleteOption, prefixName, arr_joy_btn_names]
+			_("YES"), [&, mWindow, deleteOption, prefixName, &arr_joy_btn_names]
 			{
 				//std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
 				int index = atoi(deleteOption->getSelected().c_str());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4271,25 +4271,24 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 	}
 	
 	del_choice->setSelectedChangedCallback([mWindow, del_choice, prefixName, arr_joy_btn_names, btn_choice] (std::string s) {
-		int index = atoi(del_choice->getSelected().c_str());
-		if (index == -1)
+		int index = del_choice->getSelectedIndex();
+		if (index == 0)
 			return;
 		
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
 			_("YES"), [mWindow, del_choice, prefixName, arr_joy_btn_names, btn_choice]
 			{
 				std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
-				int index = atoi(del_choice->getSelected().c_str());
+				int delIndex = (del_choice->getSelectedIndex()-1);
 
-				std::string tName = l_arr_joy_btn_names[index];
+				std::string tName = l_arr_joy_btn_names[delIndex];
 
-				l_arr_joy_btn_names.erase(l_arr_joy_btn_names.begin() + index);
+				l_arr_joy_btn_names.erase(l_arr_joy_btn_names.begin() + delIndex);
 
 				std::string sIndexes = SystemConf::getInstance()->get(prefixName + ".joy_btn_indexes");
 				std::vector<int> iIndexes = int_explode(sIndexes);	
-				iIndexes.erase(iIndexes.begin() + index);
-
-				index++;
+				int remapIndex = iIndexes[index];
+				iIndexes.erase(iIndexes.begin() + delIndex);
 
 				std::string remapNames = "";
 				for(int i=0; i < l_arr_joy_btn_names.size(); ++i)
@@ -4299,7 +4298,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 					remapNames += l_arr_joy_btn_names[i];
 				}
 				SystemConf::getInstance()->set(prefixName + ".joy_btn_names", remapNames);
-				SystemConf::getInstance()->set(prefixName + ".joy_btn_order"+std::to_string(index), "");
+				SystemConf::getInstance()->set(prefixName + ".joy_btn_order"+std::to_string(remapIndex), "");
 
 				sIndexes = "";
 				for(int i=0; i < iIndexes.size(); ++i)
@@ -4316,7 +4315,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				del_choice->selectFirstItem();
 				
 				int btn_index = atoi(btn_choice->getSelected().c_str());
-				if (btn_index == index)
+				if (btn_index >= btn_choice->size())
 					btn_choice->selectFirstItem();
 				btn_choice->remove(tName);
 			}, 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4274,7 +4274,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 			_("NO"), nullptr));
 	});
 	
-	systemConfiguration->addWithLabel(_("DELETE REMAP"), deleteOption, delFunc);	
+	systemConfiguration->addWithLabel(_("DELETE REMAP"), deleteOption, *delFunc, "", false);	
 	
 	
 	/*systemConfiguration->addSaveFunc([mWindow, deleteOption, prefixName, arr_joy_btn_names] {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4333,16 +4333,16 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 
 				int old_del_choice_val = delIndex;
 				del_choice->selectNone();
-				//del_choice->removeIndex(delIndex);
-				del_choice->selectFirstItem();
+				del_choice->removeIndex(delIndex);
+				//del_choice->selectFirstItem();
 
 				int btnIndex = btn_choice->getSelectedIndex();
 				if (btnIndex == old_del_choice_val || btnIndex >= del_choice->size())
 					btnIndex = 0;
 
 				btn_choice->selectNone();
-				//btn_choice->removeIndex(delIndex);
-				btn_choice->selectIndex(btnIndex);
+				btn_choice->removeIndex(delIndex);
+				//btn_choice->selectIndex(btnIndex);
 			},
 			_("NO"), nullptr));
 	});

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4289,7 +4289,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		i++;
 	}
 
-	del_choice->setSelectedChangedCallback([&mWindow, &btn_choice, &del_choice, prefixName](std::string s) {		
+	del_choice->setSelectedChangedCallback([mWindow, btn_choice, del_choice, prefixName](std::string s) {		
 		int delIndex = del_choice->getSelectedIndex();
 		if (delIndex <= 0)
 			return;
@@ -4297,7 +4297,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		del_choice->selectFirstItem();
 
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
-			_("YES"), [&mWindow, &btn_choice, &del_choice, prefixName, delIndex]
+			_("YES"), [mWindow, btn_choice, del_choice, prefixName, delIndex]
 			{
 				std::string remapNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_names");
 				std::vector<std::string> remap_names(explode(remapNames));
@@ -4305,7 +4305,6 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				std::string indexes = SystemConf::getInstance()->get(prefixName + ".joy_btn_indexes");
 				std::vector<int> iIndexes(int_explode(indexes));
 
-				//int delIndex = del_choice->getSelectedIndex();
 				int delCfgIndex = (delIndex-1);
 
 				std::string sRemapNames = "";
@@ -4335,14 +4334,14 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				SystemConf::getInstance()->saveSystemConf();
 
 				int old_del_choice_val = delIndex;
-				//del_choice->selectNone();
+				del_choice->selectNone();
 				del_choice->removeIndex(delIndex);
 
 				int btnIndex = btn_choice->getSelectedIndex();
 				if (btnIndex == old_del_choice_val || btnIndex >= del_choice->size())
 					btnIndex = 0;
 
-				//btn_choice->selectNone();
+				btn_choice->selectNone();
 				btn_choice->removeIndex(delIndex);
 				btn_choice->selectIndex(btnIndex);
 			},

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4116,7 +4116,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnRemapOpti
 }
 
 
-void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *mSystemConfiguration, std::string prefixName, std::string remapName)
+void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfiguration, std::string prefixName, std::string remapName)
 {
 	std::vector<std::shared_ptr<OptionListComponent<std::string>>> remap_choice;
 	
@@ -4125,8 +4125,8 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *mSystemConfigur
 	{
 		
 		remap_choice.push_back(createJoyBtnRemapOptionList(mWindow, prefixName, index));
-		mSystemConfiguration->addWithLabel(_("JOY BUTTON ")+std::to_string(index), remap_choice[index]);
-		mSystemConfiguration->addSaveFunc([mWindow, remap_choice, remapCount, prefixName, remapName, index] {
+		systemConfiguration->addWithLabel(_("JOY BUTTON ")+std::to_string(index), remap_choice[index]);
+		systemConfiguration->addSaveFunc([mWindow, remap_choice, remapCount, prefixName, remapName, index] {
 
 			for(int i=0; i < remapCount; ++i)
 			{

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4753,22 +4753,20 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 {
 	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
 
-	int enabled = atoi(SystemConf::getInstance()->get("advmame_joy_remap").c_str());
-	
 	int remapCount = atoi(SystemConf::getInstance()->get(systemName + ".joy_btn_count").c_str());
 
-	if (enabled != 1 || remapCount == 0) {
+	if (remapCount == 0) {
 		joy_btn_cfg->add("auto", "0", true);
 		return joy_btn_cfg;
 	}
-	
+
 	std::vector<std::string> joy_btn_recs;
 	for (int i=0; i < remapCount; ++i) {
 		std::string joyBtnName = SystemConf::getInstance()->get(systemName + ".joy_btn_name" + std::to_string(i));
 		if (!joyBtnName.empty())
 			joy_btn_recs.push_back(joyBtnName);
 	}
-	
+
 	int cfgIndex = atoi(SystemConf::getInstance()->get(configname + ".joy_btn_cfg").c_str());
 
 	int index = 0;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4757,9 +4757,9 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 	std::string enabled = SystemConf::getInstance()->get("advmame_joy_remap");
 		
 	std::string sRemapCount = SystemConf::getInstance()->get(core + ".joy_btn_count");
-	int remapCount = 0;
-	if (!sRemapCount.empty())
-		remapCount = std::stoi(sRemapCount);
+	//int remapCount = 0;
+	//if (!sRemapCount.empty())
+		//remapCount = atoi(sRemapCount.c_str());
 
 	joy_btn_cfg->add("auto", 0, true);
 	return joy_btn_cfg;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4122,31 +4122,32 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfigura
 	
 	int remapCount = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_count").c_str());
 	for (int index=0; index < remapCount; ++index)
-	{
-		
+	{		
 		remap_choice.push_back(createJoyBtnRemapOptionList(mWindow, prefixName, index));
 		systemConfiguration->addWithLabel(_("JOY BUTTON ")+std::to_string(index), remap_choice[index]);
-		systemConfiguration->addSaveFunc([mWindow, remap_choice, remapCount, prefixName, remapName, index] {
+		systemConfiguration->addSaveFunc([remap_choice, remapCount, prefixName, remapName, index] {
 
-			for(int i=0; i < remapCount; ++i)
-			{
-				int choice = atoi(remap_choice[i]->getSelected().c_str());
+			int choice = atoi(remap_choice[index]->getSelected().c_str());
+			if (choice == -1)
+				return;
+			for(int j=0; j < remapCount; ++j) {
+				if (j == index)
+					continue;
+				int choice2 = atoi(remap_choice[j]->getSelected().c_str());
 				if (choice == -1)
 					return;
-				for(int j=0; j < remapCount; ++j) {
-					int choice2 = atoi(remap_choice[j]->getSelected().c_str());
-					if (choice == -1)
-						return;
-					if (i != j && choice == choice2) {
-						remap_choice[j]->selectFirstItem();
-						return;
-					}
+				if (choice == choice2) {
+					remap_choice[j]->selectFirstItem();
+					return;
 				}
 			}
 
-			int remapCount = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_map_count").c_str());
-			SystemConf::getInstance()->set(prefixName + ".joy_btn_map_count", std::to_string(++remapCount));
-			SystemConf::getInstance()->set(prefixName + ".joy_btn_name" + std::to_string(remapCount), remapName);
+			int count = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_map_count").c_str());
+			if (count == 0)
+				return;
+
+			SystemConf::getInstance()->set(prefixName + ".joy_btn_map_count", std::to_string(++count));
+			SystemConf::getInstance()->set(prefixName + ".joy_btn_name" + std::to_string(count), remapName);
 
 			std::string joyRemap = "";
 			for(int i=0; i < remapCount; ++i)

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4178,9 +4178,10 @@ void GuiMenu::createBtnJoyCfgName(Window *mWindow, GuiSettings *mSystemConfigura
 	auto createText = std::make_shared<TextComponent>(mWindow, _("CREATE BUTTON REMAP"), theme->Text.font, theme->Text.color);
 	row.addElement(createText, true);
 	
-	auto updateVal = [mWindow, mSystemConfiguration, prefixName](const std::string& newVal)
+	auto updateVal = [mWindow, prefixName](const std::string& newVal)
 	{
-		GuiMenu::createBtnJoyCfgRemap(mWindow, mSystemConfiguration, prefixName, newVal);
+		GuiSettings* systemConfiguration = new GuiSettings(mWindow, "CREATE REMAP");
+		GuiMenu::createBtnJoyCfgRemap(mWindow, systemConfiguration, prefixName, newVal);
 	};
 
 	row.makeAcceptInputHandler([mWindow, createText, updateVal]

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4776,8 +4776,9 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 
 	int cfgIndex = atoi(SystemConf::getInstance()->get(configname + ".joy_btn_cfg").c_str());
 
+	int index = 0;
 	joy_btn_cfg->add("auto", "0", cfgIndex == index);
-	int index = 1;
+	index++;
 	for (auto it = joy_btn_recs.cbegin(); it != joy_btn_recs.cend(); it++) {
 		joy_btn_cfg->add(*it, std::to_string(index), cfgIndex == index);
 		index++;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4163,11 +4163,13 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::joybtnremap))
 	{
-		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, currentEmulator);
+		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, currentCore);
 		systemConfiguration->addWithLabel(_("JOY BUTTON CFG"), joyBtn_choice);
 		systemConfiguration->addSaveFunc([configName, joyBtn_choice] {
-			SystemConf::getInstance()->set(configName + ".joy_btn_cfg", joyBtn_choice->getSelected());
-			SystemConf::getInstance()->saveSystemConf();
+			if (!joyBtn_choice->getSelected().empty()) {
+				SystemConf::getInstance()->set(configName + ".joy_btn_cfg", joyBtn_choice->getSelected());
+				SystemConf::getInstance()->saveSystemConf();
+			}
 		});
 	}
 	
@@ -4747,24 +4749,29 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createNativeVideoReso
 	return emuelec_video_mode;
 }
 
-std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOptionList(Window *window, std::string configname, std::string emulator)
+std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOptionList(Window *window, std::string configname, std::string core)
 {
-	SystemConf::getInstance()->set(emulator + ".test123", "blah");
-	
 	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
-	/*std::string sRemapCount = SystemConf::getInstance()->get(emulator + ".joy_btn_count");
+	
+	SystemConf::getInstance()->set(core + ".test123", "blah");
+	std::string enabled = SystemConf::getInstance()->get("advmame_joy_remap");
+		
+	std::string sRemapCount = SystemConf::getInstance()->get(core + ".joy_btn_count");
 	int remapCount = 0;
 	if (!sRemapCount.empty())
 		remapCount = std::stoi(sRemapCount);
 
-	if (remapCount == 0) {
+	joy_btn_cfg->add("auto", 0, true);
+	return joy_btn_cfg;
+
+	/*if (enabled.compare("1") != 0 || remapCount == 0) {
 		joy_btn_cfg->add("auto", 0, true);
 		return joy_btn_cfg;
 	}
 	
 	std::vector<std::string> joy_btn_recs;
 	for (int i=0; i < remapCount; ++i) {
-		joy_btn_recs.push_back(SystemConf::getInstance()->get(emulator + ".joy_btn_name" + std::to_string(i)));
+		joy_btn_recs.push_back(SystemConf::getInstance()->get(core + ".joy_btn_name" + std::to_string(i)));
 	}
 	
 	std::string choice = SystemConf::getInstance()->get(configname + ".joy_btn_cfg");
@@ -4778,7 +4785,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 		i++;
 	}*/
 
-	return joy_btn_cfg;
+	//return joy_btn_cfg;
 }
 
 #endif 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4429,7 +4429,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 			auto btn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
 			auto del_choice = std::make_shared<OptionListComponent<std::string>>(mWindow, _("DELETE REMAP"), false);
 			systemConfiguration->addWithLabel(_("BUTTON REMAP"), btn_choice);
-			systemConfiguration->addSaveFunc([mWindow, configName, btn_choice] {
+			btn_choice->setSelectedChangedCallback([configName, btn_choice] {
 				if (btn_choice->getSelectedIndex() >= 0)
 				{
 					SystemConf::getInstance()->set(configName + ".joy_btn_cfg", btn_choice->getSelected());
@@ -5037,12 +5037,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 		return joy_btn_cfg;
 	}
 
-	int cfgIndex = 0;
-	if (!joy_btn_cfg->getSelected().empty())
-		cfgIndex = atoi(joy_btn_cfg->getSelected().c_str());
-	else
-		cfgIndex = atoi(SystemConf::getInstance()->get(configname + ".joy_btn_cfg").c_str());
-	
+	int cfgIndex = atoi(SystemConf::getInstance()->get(configname + ".joy_btn_cfg").c_str());
 	if (cfgIndex > joy_btn_recs.size())
 		cfgIndex = 0;
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4248,19 +4248,19 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
 			_("YES"), [mWindow, deleteOption, prefixName, arr_joy_btn_names]
 			{
-				//std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
+				std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
 				int index = atoi(deleteOption->getSelected().c_str());
 
-				arr_joy_btn_names.erase(arr_joy_btn_names.begin() + index);
+				l_arr_joy_btn_names.erase(l_arr_joy_btn_names.begin() + index);
 
 				index++;
 
 				std::string remapNames = "";
-				for(int i=0; i < arr_joy_btn_names.size(); ++i)
+				for(int i=0; i < l_arr_joy_btn_names.size(); ++i)
 				{
 					if (i > 0)
 						remapNames += ",";
-					remapNames += arr_joy_btn_names[i];
+					remapNames += l_arr_joy_btn_names[i];
 				}		
 				SystemConf::getInstance()->set(prefixName + ".joy_btn_names", remapNames);
 				SystemConf::getInstance()->set(prefixName + ".joy_btn_order"+std::to_string(index), "");

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4239,10 +4239,8 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		deleteOption->add(*it, std::to_string(index), false);
 		index++;
 	}
-	
-	systemConfiguration->addWithLabel(_("DELETE REMAP"), deleteOption);	
-	
-	systemConfiguration->addSaveFunc([mWindow, deleteOption, prefixName, arr_joy_btn_names] {
+
+	std::function<void()> delFunc = [mWindow, deleteOption, prefixName, arr_joy_btn_names] {
 		int index = atoi(deleteOption->getSelected().c_str());
 		if (index == -1)
 			return;
@@ -4274,7 +4272,44 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				SystemConf::getInstance()->saveSystemConf();			
 			}, 
 			_("NO"), nullptr));
-	});
+	};
+	
+	systemConfiguration->addWithLabel(_("DELETE REMAP"), deleteOption, delFunc);	
+	
+	
+	/*systemConfiguration->addSaveFunc([mWindow, deleteOption, prefixName, arr_joy_btn_names] {
+		int index = atoi(deleteOption->getSelected().c_str());
+		if (index == -1)
+			return;
+		
+		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
+			_("YES"), [mWindow, deleteOption, prefixName, arr_joy_btn_names]
+			{
+				std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
+				int index = atoi(deleteOption->getSelected().c_str());
+
+				l_arr_joy_btn_names.erase(l_arr_joy_btn_names.begin() + index);
+
+				index++;
+
+				std::string remapNames = "";
+				for(int i=0; i < l_arr_joy_btn_names.size(); ++i)
+				{
+					if (i > 0)
+						remapNames += ",";
+					remapNames += l_arr_joy_btn_names[i];
+				}		
+				SystemConf::getInstance()->set(prefixName + ".joy_btn_names", remapNames);
+				SystemConf::getInstance()->set(prefixName + ".joy_btn_order"+std::to_string(index), "");
+				
+				int count = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_map_count").c_str());
+				if (count > 0)
+					SystemConf::getInstance()->set(prefixName + ".joy_btn_map_count", std::to_string(--count));
+				
+				SystemConf::getInstance()->saveSystemConf();			
+			}, 
+			_("NO"), nullptr));
+	});*/
 }
 
 #endif

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4754,7 +4754,8 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
 
 	std::string enabled = SystemConf::getInstance()->get("advmame_joy_remap");
-		
+	SystemConf::getInstance()->set(core + ".blah123", "blah123");
+	
 	std::string sRemapCount = SystemConf::getInstance()->get(core + ".joy_btn_count");
 
 	int remapCount = 0;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4365,18 +4365,18 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		tEmulator = systemData->getEmulator(true);
 	if (!tEmulator.empty() && systemData->isFeatureSupported(tEmulator, currentCore, EmulatorFeatures::joybtnremap))
 	{
-		[&, mWindow, systemConfiguration, configName, tEmulator] {
-			if (SystemConf::getInstance()->get(configName + ".joy_btns").empty() ||
-					SystemConf::getInstance()->get(configName + ".joy_btn_count").empty() ||
-					SystemConf::getInstance()->get(configName + ".joy_btn_map_count").empty() ||
-					SystemConf::getInstance()->get(configName + ".joy_btn_names").empty())
+		[&] {
+			if (SystemConf::getInstance()->get(tEmulator + ".joy_btns").empty() ||
+					SystemConf::getInstance()->get(tEmulator + ".joy_btn_count").empty() ||
+					SystemConf::getInstance()->get(tEmulator + ".joy_btn_map_count").empty() ||
+					SystemConf::getInstance()->get(tEmulator + ".joy_btn_names").empty())
 			{
 				mWindow->pushGui(new GuiMsgBox(mWindow, 
-					configName + " /n" +
-					SystemConf::getInstance()->get(configName + ".joy_btns") + " \n" +
-					SystemConf::getInstance()->get(configName + ".joy_btn_count") + " \n" +
-					SystemConf::getInstance()->get(configName + ".joy_btn_map_count") + " \n" +
-					SystemConf::getInstance()->get(configName + ".joy_btn_names") + " \n",
+					tEmulator + " /n" +
+					SystemConf::getInstance()->get(tEmulator + ".joy_btns") + " \n" +
+					SystemConf::getInstance()->get(tEmulator + ".joy_btn_count") + " \n" +
+					SystemConf::getInstance()->get(tEmulator + ".joy_btn_map_count") + " \n" +
+					SystemConf::getInstance()->get(tEmulator + ".joy_btn_names") + " \n",
 					_("OK"), nullptr));
 				return;
 			}

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4449,7 +4449,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 			auto btn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
 			auto del_choice = std::make_shared<OptionListComponent<std::string>>(mWindow, _("DELETE REMAP"), false);
 			systemConfiguration->addWithLabel(_("BUTTON REMAP"), btn_choice);
-			btn_choice->addSaveFunc([configName, btn_choice] {
+			systemConfiguration->addSaveFunc([configName, btn_choice] {
 				if (btn_choice->getSelectedIndex() >= 0)
 				{
 					SystemConf::getInstance()->set(configName + ".joy_btn_cfg", btn_choice->getSelected());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4371,13 +4371,6 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 					SystemConf::getInstance()->get(tEmulator + ".joy_btn_map_count").empty() ||
 					SystemConf::getInstance()->get(tEmulator + ".joy_btn_names").empty())
 			{
-				mWindow->pushGui(new GuiMsgBox(mWindow, 
-					tEmulator + " /n" +
-					SystemConf::getInstance()->get(tEmulator + ".joy_btns") + " \n" +
-					SystemConf::getInstance()->get(tEmulator + ".joy_btn_count") + " \n" +
-					SystemConf::getInstance()->get(tEmulator + ".joy_btn_map_count") + " \n" +
-					SystemConf::getInstance()->get(tEmulator + ".joy_btn_names") + " \n",
-					_("OK"), nullptr));
 				return;
 			}
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4312,14 +4312,15 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 
 				SystemConf::getInstance()->saveSystemConf();
 				
+				bool btn_match = del_choice->getSelectedIndex() == btn_choice->getSelectedIndex();
 				del_choice->selectFirstItem();
 				del_choice->remove(tName);
 
-				int btn_index = atoi(btn_choice->getSelected().c_str());
-				if (btn_index >= btn_choice->size())
+				int btn_index = btn_choice->getSelectedIndex();
+				if (btn_index >= btn_choice->size() || btn_match)
 					btn_choice->selectFirstItem();
 				btn_choice->remove(tName);
-			}, 
+			},
 			_("NO"), nullptr));
 	});
 	

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4251,7 +4251,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				//std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
 				int index = atoi(deleteOption->getSelected().c_str());
 
-				arr_joy_btn_names.erase(arr_joy_btn_names.begin() + index);
+				arr_joy_btn_names->erase(arr_joy_btn_names->begin() + index);
 
 				index++;
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4163,8 +4163,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	}
 
 	std::string tEmulator = (systemData->getEmulator().empty() ? currentEmulator : systemData->getEmulator())
-	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::joybtnremap) ||
-			systemData->isFeatureSupported(tEmulator, currentCore, EmulatorFeatures::joybtnremap))
+	if (systemData->isFeatureSupported(tEmulator, currentCore, EmulatorFeatures::joybtnremap))
 	{
 		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
 		systemConfiguration->addWithLabel(_("JOY BUTTON CFG"), joyBtn_choice);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4317,7 +4317,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				del_choice->remove(tName);
 
 				int btn_index = btn_choice->getSelectedIndex();
-				if (btn_index >= btn_choice->size() || btn_match)
+				if (btn_index >= (btn_choice->size()-1) || btn_match)
 					btn_choice->selectFirstItem();
 				btn_choice->remove(tName);
 			},

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4753,9 +4753,9 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 {
 	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
 
-	int enabled = SystemConf::getInstance()->getInt("advmame_joy_remap");
+	int enabled = atoi(SystemConf::getInstance()->get("advmame_joy_remap").c_str());
 	
-	int remapCount = SystemConf::getInstance()->getInt(systemName + ".joy_btn_count");
+	int remapCount = atoi(SystemConf::getInstance()->get(systemName + ".joy_btn_count").c_str();
 
 	if (enabled != 1 || remapCount == 0) {
 		joy_btn_cfg->add("auto", "0", true);
@@ -4769,7 +4769,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 			joy_btn_recs.push_back(joyBtnName);
 	}
 	
-	int cfgIndex = SystemConf::getInstance()->getInt(configname + ".joy_btn_cfg");
+	int cfgIndex = atoi(SystemConf::getInstance()->get(configname + ".joy_btn_cfg").c_str());
 
 	int index = 0;
 	for (auto it = joy_btn_recs.cbegin(); it != joy_btn_recs.cend(); it++) {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4757,11 +4757,12 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 	std::string enabled = SystemConf::getInstance()->get("advmame_joy_remap");
 		
 	std::string sRemapCount = SystemConf::getInstance()->get(core + ".joy_btn_count");
-	//int remapCount = 0;
-	//if (!sRemapCount.empty())
-		//remapCount = atoi(sRemapCount.c_str());
 
-	joy_btn_cfg->add("auto", 0, true);
+	int remapCount = 0;
+	if (!sRemapCount.empty())
+		remapCount = atoi(sRemapCount.c_str());
+
+	joy_btn_cfg->add("auto", "0", true);
 	return joy_btn_cfg;
 
 	/*if (enabled.compare("1") != 0 || remapCount == 0) {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4162,7 +4162,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		});
 	}
 
-	std::string tEmulator = (currentEmulator == "auto") ? systemData->getEmulator(true) : currentEmulator;
+	std::string tEmulator = (currentEmulator == "auto") ? systemData->getEmulator(false) : currentEmulator;
 	if (systemData->isFeatureSupported(tEmulator, currentCore, EmulatorFeatures::joybtnremap))
 	{
 		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
@@ -4758,12 +4758,12 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 	int remapCount = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_count").c_str());
 
 	if (remapCount == 0) {
-		joy_btn_cfg->add("auto", "0", true);
+		
 		return joy_btn_cfg;
 	}
 
 	std::vector<std::string> joy_btn_recs;
-	for (int i=0; i < remapCount; ++i) {
+	for (int i=1; i < remapCount; ++i) {
 		std::string joyBtnName = SystemConf::getInstance()->get(prefixName + ".joy_btn_name" + std::to_string(i));
 		if (!joyBtnName.empty())
 			joy_btn_recs.push_back(joyBtnName);
@@ -4772,6 +4772,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 	int cfgIndex = atoi(SystemConf::getInstance()->get(configname + ".joy_btn_cfg").c_str());
 
 	int index = 0;
+	joy_btn_cfg->add("auto", "0", cfgIndex == index);
 	for (auto it = joy_btn_recs.cbegin(); it != joy_btn_recs.cend(); it++) {
 		joy_btn_cfg->add(*it, std::to_string(index), cfgIndex == index);
 		index++;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4081,6 +4081,50 @@ void GuiMenu::popGameConfigurationGui(Window* mWindow, FileData* fileData)
 		fileData);
 }
 
+// TODO 
+
+#ifdef _ENABLEEMUELEC
+void GuiMenu::createJoyBtnCfgOptionList(Window *mWindow, std::string title)
+{
+	GuiSettings* systemConfiguration = new GuiSettings(mWindow, title.c_str());
+
+	auto theme = ThemeData::getMenuTheme();
+	std::shared_ptr<Font> font = theme->Text.font;
+	unsigned int color = theme->Text.color;
+
+	ComponentListRow row;
+	
+	mTextRemap = std::make_shared<TextComponent>(mWindow, _("CREATE BUTTON REMAP"), font, color);
+	row.addElement(mTextRemap, true);
+
+	auto spacer = std::make_shared<GuiComponent>(mWindow);
+	spacer->setSize(Renderer::getScreenWidth() * 0.005f, 0);
+	row.addElement(spacer, false);
+
+	auto bracket = std::make_shared<ImageComponent>(mWindow);
+
+	bracket->setResize(Vector2f(0, lbl->getFont()->getLetterHeight()));
+	row.addElement(bracket, false);
+
+	auto updateVal = [this](const std::string& newVal)
+	{
+		mTextRemap->setValue(Utils::String::toUpper(newVal));
+
+		// save to config
+	};
+
+	row.makeAcceptInputHandler([this, updateVal]
+	{
+		if (Settings::getInstance()->getBool("UseOSK"))
+			mWindow->pushGui(new GuiTextEditPopupKeyboard(mWindow, _("CREATE BUTTON REMAP NAME"), mTextRemap->getValue(), updateVal, false));
+		else
+			mWindow->pushGui(new GuiTextEditPopup(mWindow, _("CREATE BUTTON REMAP NAME"), mTextRemap->getValue(), updateVal, false));
+	});
+
+	addRow(row);
+}
+#endif
+
 void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, std::string configName, SystemData *systemData, FileData* fileData, bool selectCoreLine)
 {
 	// The system configuration
@@ -4162,7 +4206,6 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		});
 	}
 
-	//std::string tEmulator = (currentEmulator == "auto") ? systemData->getEmulator(true) : currentEmulator;
 	std::string tEmulator = fileData != nullptr ? fileData->getEmulator(true) : systemData->getEmulator(true);
 	if (tEmulator == "auto")
 		tEmulator = systemData->getEmulator(true);
@@ -4173,9 +4216,16 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		systemConfiguration->addSaveFunc([configName, joyBtn_choice] {
 				SystemConf::getInstance()->set(configName + ".joy_btn_cfg", joyBtn_choice->getSelected());
 				SystemConf::getInstance()->saveSystemConf();
+				
+				
+		auto joyBtn_create = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
+		systemConfiguration->addWithLabel(_("CREATE BUTTON REMAP"), joyBtn_choice);
 		});
+		
+		
+		addCreateButtonRemapToMenu(mWindow, title);
 	}
-	
+
 #endif 
 
 	// Screen ratio choice

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4972,7 +4972,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 	//int nameCount=remapCount+1;
 
 	int cfgIndex = atoi(SystemConf::getInstance()->get(configname + ".joy_btn_cfg").c_str());
-	if (cfgIndex >= joy_btn_recs.size())
+	if (cfgIndex > joy_btn_recs.size())
 		cfgIndex = 0;
 
 	int index = 0;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4339,7 +4339,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 
 				int btn_index = btn_choice->getSelectedIndex();
 
-				if (btn_index == old_del_choice_val)
+				if (btn_index == old_del_choice_val || btn_index >= (btn_size()-1))
 					btn_choice->selectFirstItem();
 				btn_choice->remove(tName);
 			},

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4151,6 +4151,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	auto customFeatures = systemData->getCustomFeatures(currentEmulator, currentCore);
 
 #ifdef _ENABLEEMUELEC
+
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::nativevideo))
 	{
 		auto videoNativeResolutionMode_choice = createNativeVideoResolutionModeOptionList(mWindow, configName);
@@ -4160,8 +4161,9 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 			SystemConf::getInstance()->saveSystemConf();
 		});
 	}
-	
-	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::joybtnremap))
+
+	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::joybtnremap) ||
+			systemData->isFeatureSupported(systemData->getEmulator(), systemData->getCore(), EmulatorFeatures::joybtnremap))
 	{
 		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, currentCore);
 		systemConfiguration->addWithLabel(_("JOY BUTTON CFG"), joyBtn_choice);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4237,7 +4237,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 	systemConfiguration->addWithLabel(_("DELETE REMAP"), deleteOption);	
 	
 	systemConfiguration->addSaveFunc([mWindow, deleteOption, prefixName, arr_joy_btn_names] {
-		mWindow->pushGui(new GuiMsgBox(window, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
+		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
 			_("YES"), [mWindow, deleteOption, prefixName, arr_joy_btn_names]
 			{
 				std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4108,6 +4108,15 @@ static std::vector<int> int_explode(std::string sData, char delimeter=',')
 	return arr;
 }
 
+
+static std::string toupper(std::string s)
+{
+	std::for_each(s.begin(), s.end(), [](char & c){
+	    c = ::toupper(c);
+	});	
+	return s;
+}
+
 std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnRemapOptionList(Window *window, std::string prefixName, int btnIndex)
 {
 	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
@@ -4237,6 +4246,18 @@ void GuiMenu::createBtnJoyCfgName(Window *mWindow, GuiSettings *systemConfigurat
 			mWindow->pushGui(new GuiMsgBox(mWindow, _("YOU CANNOT HAVE COMMAS IN REMAP NAME"), _("OK"), nullptr));
 		  return;
 		}
+		
+		std::string remapNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_names");
+		std::vector<std::string> arr_btn_names(explode(remapNames));
+		std::string newName = toupper(newVal);
+		for (int i=0; i < arr_btn_names.size(); ++i) {
+			std::string tName = toupper(arr_btn_names[i]);
+			if (newName == tName) {
+				mWindow->pushGui(new GuiMsgBox(mWindow, _("REMAP NAME MUST BE UNIQUE"), _("OK"), nullptr));
+				return;
+			}
+		}
+
 		GuiSettings* systemConfiguration = new GuiSettings(mWindow, "CREATE REMAP");
 		GuiMenu::createBtnJoyCfgRemap(mWindow, systemConfiguration, btn_choice, del_choice, prefixName, newVal);
 		mWindow->pushGui(systemConfiguration);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4304,11 +4304,11 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 
 				std::vector<std::string> tNames = remap_names;
 				int delCfgIndex = (delIndex-1);
-				//tNames.erase(tNames.begin() + delCfgIndex);
+				tNames.erase(tNames.begin() + delCfgIndex);
 
 				std::vector<int> tIndexes = iIndexes;
 				//int remapIndex = tIndexes[delIndex];
-				//tIndexes.erase(tIndexes.begin() + delCfgIndex);
+				tIndexes.erase(tIndexes.begin() + delCfgIndex);
 
 				std::string sRemapNames = "";
 				int i;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4753,32 +4753,23 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 {
 	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
 
-	std::string enabled = SystemConf::getInstance()->get("advmame_joy_remap");
-	SystemConf::getInstance()->set(systemName + ".blah123", "blah123");
+	int enabled = SystemConf::getInstance()->getInt("advmame_joy_remap");
 	
-	std::string sRemapCount = SystemConf::getInstance()->get(systemName + ".joy_btn_count");
+	int remapCount = SystemConf::getInstance()->getInt(systemName + ".joy_btn_count");
 
-	int remapCount = 0;
-	if (!sRemapCount.empty())
-		remapCount = atoi(sRemapCount.c_str());
-
-	joy_btn_cfg->add("auto", "0", true);
-
-	if (enabled.compare("1") != 0 || remapCount == 0) {
+	if (enabled != 1 || remapCount == 0) {
+		joy_btn_cfg->add("auto", "0", true);
 		return joy_btn_cfg;
 	}
 	
 	std::vector<std::string> joy_btn_recs;
-	for (int i=1; i < remapCount; ++i) {
+	for (int i=0; i < remapCount; ++i) {
 		std::string joyBtnName = SystemConf::getInstance()->get(systemName + ".joy_btn_name" + std::to_string(i));
 		if (!joyBtnName.empty())
 			joy_btn_recs.push_back(joyBtnName);
 	}
 	
-	std::string choice = SystemConf::getInstance()->get(configname + ".joy_btn_cfg");
-	int cfgIndex = 0;
-	if (!choice.empty())
-		cfgIndex = std::stoi(choice);
+	int cfgIndex = SystemConf::getInstance()->getInt(configname + ".joy_btn_cfg");
 
 	int index = 0;
 	for (auto it = joy_btn_recs.cbegin(); it != joy_btn_recs.cend(); it++) {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4298,10 +4298,14 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		if (index == 0)
 			return;
 		int delIndex = del_choice->getSelectedIndex();
+		SystemConf::getInstance()->set(prefixName + ".selected", std::to_string(delIndex));
+		SystemConf::getInstance()->set(prefixName + ".value", s);
+		return;
+		
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
 			_("YES"), [mWindow, btn_choice, del_choice, prefixName, arr_btn_names, iIndexes, delIndex]
 			{
-				SystemConf::getInstance()->set(prefixName + ".value", s);
+				
 				std::vector<std::string> tNames(arr_btn_names);
 				int delCfgIndex = (delIndex-1);
 				tNames.erase(tNames.begin() + delIndex);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4752,16 +4752,21 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
 	int index = SystemConf::getInstance()->get(emulator + ".joy_btn_count");
 	
-	std::vector<std::string> joy_btn_names;
-	for (int i=0; i < index; ++i)
-		joy_btn_names.push_back(SystemConf::getInstance()->get(emulator + ".joy_btn_name"+i));
-
+	std::vector<std::pair<std::string,std::string>> joy_btn_recs;
+	for (int i=0; i < index; ++i) {
+		std::string name = SystemConf::getInstance()->get(emulator + ".joy_btn_name"+i);
+		std::string val = SystemConf::getInstance()->get(emulator + ".joy_btn_order"+i);
+		std::pair<std::string,std:string> rec{name,val};
+		joy_btn_recs.push_back(rec);
+	}
+	
 	std::string index = SystemConf::getInstance()->get(configname + ".joy_btn_cfg");
 	if (index.empty())
 		index = "auto";
 
-	for (auto it = joy_btn_names.cbegin(); it != joy_btn_names.cend(); it++) {
-		joy_btn_cfg->add(*it, *it, index == *it);
+// TODO
+	for (auto it = joy_btn_recs.cbegin(); it != joy_btn_recs.cend(); it++) {
+		joy_btn_cfg->add(it->first, it->second, index == it->second);
 	}
 
 	return joy_btn_cfg;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4084,7 +4084,7 @@ void GuiMenu::popGameConfigurationGui(Window* mWindow, FileData* fileData)
 // TODO 
 
 #ifdef _ENABLEEMUELEC
-void GuiMenu::createBtnJoyCfg(Window *mWindow, GuiSettings *mSystemConfiguration, std::string title)
+void GuiMenu::createBtnJoyCfg(Window *mWindow, GuiSettings *mSystemConfiguration, std::string prefixName)
 {
 	auto theme = ThemeData::getMenuTheme();
 
@@ -4093,19 +4093,22 @@ void GuiMenu::createBtnJoyCfg(Window *mWindow, GuiSettings *mSystemConfiguration
 	auto text = std::make_shared<TextComponent>(mWindow, _("CREATE BUTTON REMAP"), theme->Text.font, theme->Text.color);
 	row.addElement(text, true);
 
-	auto updateVal = [text](const std::string& newVal)
+	auto updateVal = [text,prefixName](const std::string& newVal)
 	{
-		text->setValue(Utils::String::toUpper(newVal));
+		int remapCount = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_count").c_str());
+		SystemConf::getInstance()->set(prefixName + ".joy_btn_count", std::to_string(++remapCount));
+		SystemConf::getInstance()->set(prefixName + ".joy_btn_name" + std::to_string(remapCount), newVal);
 
+		
 		// save to config
 	};
 
 	row.makeAcceptInputHandler([mWindow, text, updateVal]
 	{
 		if (Settings::getInstance()->getBool("UseOSK"))
-			mWindow->pushGui(new GuiTextEditPopupKeyboard(mWindow, _("REMAP NAME"), text->getValue(), updateVal, false));
+			mWindow->pushGui(new GuiTextEditPopupKeyboard(mWindow, _("REMAP NAME"), "", updateVal, false));
 		else
-			mWindow->pushGui(new GuiTextEditPopup(mWindow, _("REMAP NAME"), text->getValue(), updateVal, false));
+			mWindow->pushGui(new GuiTextEditPopup(mWindow, _("REMAP NAME"), "", updateVal, false));
 	});
 
 	mSystemConfiguration->addRow(row);
@@ -4205,7 +4208,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 				SystemConf::getInstance()->saveSystemConf();
 		});
 
-		createBtnJoyCfg(mWindow, systemConfiguration, title);
+		createBtnJoyCfg(mWindow, systemConfiguration, tEmulator);
 	}
 
 #endif 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4274,7 +4274,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 			_("NO"), nullptr));
 	});
 	
-	systemConfiguration->addWithLabel(_("DELETE REMAP"), deleteOption, *delFunc, "", false);	
+	systemConfiguration->addWithLabel(_("DELETE REMAP"), deleteOption, delFunc, "", false);	
 	
 	
 	/*systemConfiguration->addSaveFunc([mWindow, deleteOption, prefixName, arr_joy_btn_names] {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4132,38 +4132,38 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfigura
 	}
 
 	systemConfiguration->addSaveFunc([mWindow, remap_choice, remapCount, prefixName, remapName] {
+		int err = 0;
+		int j=0;
+		[&] {
+			for(int i=0; i < remapCount; ++i) {
+				int choice = atoi(remap_choice[i]->getSelected().c_str());
+				if (choice == -1) {
+					err=1;
+					break;
+				}
+				for(j=0; j < remapCount; ++j) {
+					int choice2 = atoi(remap_choice[j]->getSelected().c_str());
+					if (choice2 == -1) {
+						err=1;
+						return;
+					}
+					if (i != j && choice == choice2) {
+						err=1;
+						return;
+					}
+				}
+			}
+		}();
+
+		if (err > 0)
+		{
+			mWindow->pushGui(new GuiMsgBox(mWindow, _("ERROR - Remap is not configured properly, aborting. All buttons must be assigned and no duplicates."), "OK", nullptr));
+			return;
+		}
+		
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO CREATE THE REMAP?"),
 			_("YES"), [mWindow, remap_choice, remapCount, prefixName, remapName]
 		{		
-			int err = 0;
-			int j=0;
-			[&] {
-				for(int i=0; i < remapCount; ++i) {
-					int choice = atoi(remap_choice[i]->getSelected().c_str());
-					if (choice == -1) {
-						err=1;
-						break;
-					}
-					for(j=0; j < remapCount; ++j) {
-						int choice2 = atoi(remap_choice[j]->getSelected().c_str());
-						if (choice2 == -1) {
-							err=1;
-							return;
-						}
-						if (i != j && choice == choice2) {
-							err=1;
-							return;
-						}
-					}
-				}
-			}();
-
-			if (err > 0)
-			{
-				mWindow->pushGui(new GuiMsgBox(mWindow, _("ERROR - Remap is not configured properly, aborting. All buttons must be assigned and no duplicates."), "OK", nullptr));
-				return;
-			}
-
 			int count = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_map_count").c_str());
 			if (count == 0)
 				return;
@@ -4241,13 +4241,15 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 	systemConfiguration->addWithLabel(_("DELETE REMAP"), deleteOption);	
 	
 	systemConfiguration->addSaveFunc([mWindow, deleteOption, prefixName, arr_joy_btn_names] {
+		int index = atoi(deleteOption->getSelected().c_str());
+		if (index == -1)
+			return;
+		
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
 			_("YES"), [mWindow, deleteOption, prefixName, arr_joy_btn_names]
 			{
 				std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
 				int index = atoi(deleteOption->getSelected().c_str());
-				if (index == -1)
-					return;
 
 				l_arr_joy_btn_names.erase(l_arr_joy_btn_names.begin() + index);
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4332,17 +4332,17 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				SystemConf::getInstance()->saveSystemConf();
 
 				int old_del_choice_val = delIndex;
-				del_choice->selectNone();
-				del_choice->removeIndex(delIndex);
-				del_choice->selectFirstItem();
+				//del_choice->selectNone();
+				//del_choice->removeIndex(delIndex);
+				//del_choice->selectFirstItem();
 
 				int btnIndex = btn_choice->getSelectedIndex();
 				if (btnIndex == old_del_choice_val || btnIndex >= del_choice->size())
 					btnIndex = 0;
 
-				btn_choice->selectNone();
-				btn_choice->removeIndex(delIndex);
-				btn_choice->selectIndex(btnIndex);
+				//btn_choice->selectNone();
+				//btn_choice->removeIndex(delIndex);
+				//btn_choice->selectIndex(btnIndex);
 			},
 			_("NO"), nullptr));
 	});

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4123,42 +4123,44 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfigura
 	int remapCount = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_count").c_str());
 	for (int index=0; index < remapCount; ++index)
 	{		
-		remap_choice.push_back(createJoyBtnRemapOptionList(mWindow, prefixName, index));
+		auto remap = createJoyBtnRemapOptionList(mWindow, prefixName, index);
+		remap_choice.push_back(remap);
 		systemConfiguration->addWithLabel(_("JOY BUTTON ")+std::to_string(index), remap_choice[index]);
-		systemConfiguration->addSaveFunc([remap_choice, remapCount, prefixName, remapName, index] {
+	}
 
-			int choice = atoi(remap_choice[index]->getSelected().c_str());
+	systemConfiguration->addSaveFunc([remap_choice, remapCount, prefixName, remapName] {
+		int j=0;
+		for(int i=0; i < remapCount; ++i) {
+			int choice = atoi(remap_choice[i]->getSelected().c_str());
 			if (choice == -1)
 				return;
-			for(int j=0; j < remapCount; ++j) {
-				if (j == index)
-					continue;
+			for(j=0; j < remapCount; ++j) {
 				int choice2 = atoi(remap_choice[j]->getSelected().c_str());
 				if (choice == -1)
 					return;
-				if (choice == choice2) {
+				if (i != j && choice == choice2) {
 					remap_choice[j]->selectFirstItem();
 					return;
 				}
 			}
+		}
 
-			int count = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_map_count").c_str());
-			if (count == 0)
-				return;
+		int count = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_map_count").c_str());
+		if (count == 0)
+			return;
 
-			SystemConf::getInstance()->set(prefixName + ".joy_btn_map_count", std::to_string(++count));
-			SystemConf::getInstance()->set(prefixName + ".joy_btn_name" + std::to_string(count), remapName);
+		SystemConf::getInstance()->set(prefixName + ".joy_btn_map_count", std::to_string(++count));
+		SystemConf::getInstance()->set(prefixName + ".joy_btn_name" + std::to_string(count), remapName);
 
-			std::string joyRemap = "";
-			for(int i=0; i < remapCount; ++i)
-			{
-				if (i > 0)
-					joyRemap += " ";
-				joyRemap += remap_choice[i]->getSelected();
-			}
-			SystemConf::getInstance()->set(prefixName + ".joy_btn_order" + std::to_string(remapCount), joyRemap);
-		});	
-	}
+		std::string joyRemap = "";
+		for(int i=0; i < remapCount; ++i)
+		{
+			if (i > 0)
+				joyRemap += " ";
+			joyRemap += remap_choice[i]->getSelected();
+		}
+		SystemConf::getInstance()->set(prefixName + ".joy_btn_order" + std::to_string(remapCount), joyRemap);
+	});		
 }
 
 void GuiMenu::createBtnJoyCfgName(Window *mWindow, GuiSettings *mSystemConfiguration, std::string prefixName)

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4240,7 +4240,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		index++;
 	}
 
-	std::function<void()> delFunc = [mWindow, deleteOption, prefixName, arr_joy_btn_names] {
+	std::function<void()> delFunc([mWindow, deleteOption, prefixName, arr_joy_btn_names] {
 		int index = atoi(deleteOption->getSelected().c_str());
 		if (index == -1)
 			return;
@@ -4272,7 +4272,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				SystemConf::getInstance()->saveSystemConf();			
 			}, 
 			_("NO"), nullptr));
-	};
+	}());
 	
 	systemConfiguration->addWithLabel(_("DELETE REMAP"), deleteOption, delFunc);	
 	

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4749,8 +4749,18 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createNativeVideoReso
 
 std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOptionList(Window *window, std::string configname, std::string emulator)
 {
+	SystemConf::getInstance()->set(emulator + ".test123");
+	
 	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
-	int index = std::stoi(SystemConf::getInstance()->get(emulator + ".joy_btn_count"));
+	std::string sRemapCount = SystemConf::getInstance()->get(emulator + ".joy_btn_count");
+	int remapCount = 0;
+	if (!remapCount.empty())
+		remapCount = std::stoi(remapCount);
+	
+	if (remapCount == 0) {
+		joy_btn_cfg->add("auto", 0, true);
+		return joy_btn_cfg;
+	}
 	
 	std::vector<std::string> joy_btn_recs;
 	for (int i=0; i < index; ++i) {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4292,13 +4292,13 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		i++;
 	}
 
-	del_choice->setSelectedChangedCallback([mWindow, btn_choice, del_choice, prefixName, arr_btn_names, iIndexes](std::string s) {
+	del_choice->setSelectedChangedCallback([mWindow, &btn_choice, &del_choice, prefixName, arr_btn_names, iIndexes](std::string s) {
 		int delIndex = del_choice->getSelectedIndex();
 		if (delIndex == 0)
 			return;
 
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
-			_("YES"), [mWindow, btn_choice, del_choice, prefixName, arr_btn_names, iIndexes, delIndex]
+			_("YES"), [mWindow, &btn_choice, &del_choice, prefixName, arr_btn_names, iIndexes, delIndex]
 			{
 				
 				std::vector<std::string> tNames(arr_btn_names);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4429,7 +4429,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 			auto btn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
 			auto del_choice = std::make_shared<OptionListComponent<std::string>>(mWindow, _("DELETE REMAP"), false);
 			systemConfiguration->addWithLabel(_("BUTTON REMAP"), btn_choice);
-			btn_choice->setSelectedChangedCallback([configName, btn_choice] {
+			btn_choice->setSelectedChangedCallback([configName, btn_choice](std::string s) {
 				if (btn_choice->getSelectedIndex() >= 0)
 				{
 					SystemConf::getInstance()->set(configName + ".joy_btn_cfg", btn_choice->getSelected());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4098,7 +4098,7 @@ void GuiMenu::createBtnJoyCfgName(Window *mWindow, std::string prefixName)
 		SystemConf::getInstance()->set(prefixName + ".joy_btn_count", std::to_string(++remapCount));
 		SystemConf::getInstance()->set(prefixName + ".joy_btn_name" + std::to_string(remapCount), newVal);
 
-		MenuGui::createBtnJoyCfgRemap(mWindow, prefixName);
+		GuiMenu::createBtnJoyCfgRemap(mWindow, prefixName);
 	};
 
 	if (Settings::getInstance()->getBool("UseOSK"))
@@ -4814,7 +4814,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 		joy_btn_cfg->add(*it, std::to_string(index), cfgIndex == index);
 		index++;
 	}
-	joy_btn_cfg->add("add new", std::to_string(joy_btn_cfg.size()-1), cfgIndex == index);
+	joy_btn_cfg->add("add new", std::to_string(joy_btn_cfg->size()-1), cfgIndex == index);
 	return joy_btn_cfg;
 }
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4282,9 +4282,6 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 	std::string remapNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_names");
 	std::vector<std::string> remap_names(explode(remapNames));
 
-	std::string sIndexes = SystemConf::getInstance()->get(prefixName + ".joy_btn_indexes");
-	std::vector<int> iIndexes(int_explode(sIndexes));
-
 	del_choice->add("NONE", "0", true);
 	int i = 1;
 	for (auto it = remap_names.cbegin(); it != remap_names.cend(); it++) {
@@ -4292,7 +4289,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		i++;
 	}
 
-	del_choice->setSelectedChangedCallback([mWindow, btn_choice, del_choice, prefixName, remap_names, iIndexes](std::string s) {		
+	del_choice->setSelectedChangedCallback([&mWindow, &btn_choice, &del_choice, prefixName, remap_names, iIndexes](std::string s) {		
 		int delIndex = del_choice->getSelectedIndex();
 		if (delIndex <= 0)
 			return;
@@ -4300,8 +4297,14 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		del_choice->selectFirstItem();
 
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
-			_("YES"), [mWindow, btn_choice, del_choice, prefixName, remap_names, iIndexes, delIndex]
+			_("YES"), [&mWindow, &btn_choice, &del_choice, prefixName, delIndex]
 			{
+				std::string remapNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_names");
+				std::vector<std::string> remap_names(explode(remapNames));
+
+				std::string indexes = SystemConf::getInstance()->get(prefixName + ".joy_btn_indexes");
+				std::vector<int> iIndexes(int_explode(indexes));
+
 				//int delIndex = del_choice->getSelectedIndex();
 				int delCfgIndex = (delIndex-1);
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4752,8 +4752,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createNativeVideoReso
 std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOptionList(Window *window, std::string configname, std::string core)
 {
 	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
-	
-	SystemConf::getInstance()->set(core + ".test123", "blah");
+
 	std::string enabled = SystemConf::getInstance()->get("advmame_joy_remap");
 		
 	std::string sRemapCount = SystemConf::getInstance()->get(core + ".joy_btn_count");
@@ -4763,30 +4762,30 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 		remapCount = atoi(sRemapCount.c_str());
 
 	joy_btn_cfg->add("auto", "0", true);
-	return joy_btn_cfg;
 
-	/*if (enabled.compare("1") != 0 || remapCount == 0) {
-		joy_btn_cfg->add("auto", 0, true);
+	if (enabled.compare("1") != 0 || remapCount == 0) {
 		return joy_btn_cfg;
 	}
 	
 	std::vector<std::string> joy_btn_recs;
-	for (int i=0; i < remapCount; ++i) {
-		joy_btn_recs.push_back(SystemConf::getInstance()->get(core + ".joy_btn_name" + std::to_string(i)));
+	for (int i=1; i < remapCount; ++i) {
+		std::string joyBtnName = SystemConf::getInstance()->get(core + ".joy_btn_name" + std::to_string(i));
+		if (!joyBtnName.empty())
+			joy_btn_recs.push_back(joyBtnName);
 	}
 	
 	std::string choice = SystemConf::getInstance()->get(configname + ".joy_btn_cfg");
-	int cindex = 0;
+	int cfgIndex = 0;
 	if (!choice.empty())
-		cindex = std::stoi(choice);
+		cfgIndex = std::stoi(choice);
 
-	int i = 0;
+	int index = 0;
 	for (auto it = joy_btn_recs.cbegin(); it != joy_btn_recs.cend(); it++) {
-		joy_btn_cfg->add(*it, std::to_string(i), cindex == i);
+		joy_btn_cfg->add(*it, std::to_string(i), cfgIndex == index);
 		i++;
-	}*/
+	}
 
-	//return joy_btn_cfg;
+	return joy_btn_cfg;
 }
 
 #endif 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4146,7 +4146,7 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfigura
 		systemConfiguration->addWithLabel(_("JOY BUTTON ")+std::to_string(index), remap_choice[index]);
 	}
 
-	systemConfiguration->addSaveFunc([mWindow, remap_choice, del_choice, btn_choice, remapCount, prefixName, remapName] {
+	systemConfiguration->addSaveFunc([mWindow, remap_choice, del_choice, btn_choice, remapCount, prefixName, remapName, remapNames] {
 		int err = 0;
 		if (remapCount == 0)
 			err = 1;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4292,17 +4292,17 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		del_choice->add(*it, std::to_string(iIndexes[i]), false);
 		i++;
 	}
-	
+
 	systemConfiguration->addSaveFunc([mWindow, btn_choice, del_choice, prefixName, arr_btn_names, iIndexes] {
 		int index = del_choice->getSelectedIndex();
 		if (index == 0)
 			return;
-		
+		int delIndex = this->getSelectedIndex();
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
-			_("YES"), [mWindow, btn_choice, del_choice, prefixName, arr_btn_names, iIndexes]
+			_("YES"), [mWindow, btn_choice, del_choice, prefixName, arr_btn_names, iIndexes, delIndex]
 			{
 				std::vector<std::string> tNames(arr_btn_names);
-				int delIndex = (del_choice->getSelectedIndex()-1);
+				int delCfgIndex = (delIndex-1);
 				tNames.erase(tNames.begin() + delIndex);
 
 				std::vector<int> tIndexes(iIndexes);
@@ -4333,7 +4333,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 
 				std::string tName = del_choice->getSelectedName();
 
-				int old_del_choice_val = del_choice->getSelectedIndex();
+				int old_del_choice_val = delIndex;
 				del_choice->selectFirstItem();
 				del_choice->remove(tName);
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4084,36 +4084,31 @@ void GuiMenu::popGameConfigurationGui(Window* mWindow, FileData* fileData)
 // TODO 
 
 #ifdef _ENABLEEMUELEC
-void GuiMenu::createBtnJoyCfg(Window *mWindow, std::string title)
+void GuiMenu::createBtnJoyCfg(Window *mWindow, GuiSettings *mSystemConfiguration, std::string title)
 {
-	GuiSettings* systemConfiguration = new GuiSettings(mWindow, title.c_str());
-
 	auto theme = ThemeData::getMenuTheme();
-	std::shared_ptr<Font> font = theme->Text.font;
-	unsigned int color = theme->Text.color;
 
 	ComponentListRow row;
-	
-	auto mTextRemap = std::make_shared<TextComponent>(mWindow, _("CREATE BUTTON REMAP"), font, color);
-	row.addElement(mTextRemap, true);
 
+	auto text = std::make_shared<TextComponent>(mWindow, _("CREATE BUTTON REMAP"), theme->Text.font, theme->Text.color);
+	row.addElement(text, true);
 
-	auto updateVal = [mTextRemap](const std::string& newVal)
+	auto updateVal = [text](const std::string& newVal)
 	{
-		mTextRemap->setValue(Utils::String::toUpper(newVal));
+		text->setValue(Utils::String::toUpper(newVal));
 
 		// save to config
 	};
 
-	row.makeAcceptInputHandler([mWindow, mTextRemap, updateVal]
+	row.makeAcceptInputHandler([mWindow, text, updateVal]
 	{
 		if (Settings::getInstance()->getBool("UseOSK"))
-			mWindow->pushGui(new GuiTextEditPopupKeyboard(mWindow, _("CREATE BUTTON REMAP NAME"), mTextRemap->getValue(), updateVal, false));
+			mWindow->pushGui(new GuiTextEditPopupKeyboard(mWindow, _("REMAP NAME"), text->getValue(), updateVal, false));
 		else
-			mWindow->pushGui(new GuiTextEditPopup(mWindow, _("CREATE BUTTON REMAP NAME"), mTextRemap->getValue(), updateVal, false));
+			mWindow->pushGui(new GuiTextEditPopup(mWindow, _("REMAP NAME"), text->getValue(), updateVal, false));
 	});
 
-	systemConfiguration->addRow(row);
+	mSystemConfiguration->addRow(row, false);
 }
 #endif
 
@@ -4210,7 +4205,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 				SystemConf::getInstance()->saveSystemConf();
 		});
 
-		createBtnJoyCfg(mWindow, title);
+		createBtnJoyCfg(mWindow, systemConfiguration, title);
 	}
 
 #endif 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4303,11 +4303,11 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				
 				std::vector<std::string> tNames(arr_btn_names);
 				int delCfgIndex = (delIndex-1);
-				tNames.erase(tNames.begin() + delIndex);
+				tNames.erase(tNames.begin() + delCfgIndex);
 
 				std::vector<int> tIndexes(iIndexes);
 				int remapIndex = tIndexes[delIndex];
-				tIndexes.erase(tIndexes.begin() + delIndex);
+				tIndexes.erase(tIndexes.begin() + delCfgIndex);
 
 				std::string sRemapNames = "";
 				int i;
@@ -4332,21 +4332,21 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				SystemConf::getInstance()->saveSystemConf();
 
 				int old_del_choice_val = delIndex;
-				//del_choice->selectNone();
-				//del_choice->removeIndex(delIndex);
-				//del_choice->selectFirstItem();
+				del_choice->selectNone();
+				del_choice->removeIndex(delIndex);
+				del_choice->selectFirstItem();
 
 				int btnIndex = btn_choice->getSelectedIndex();
 				if (btnIndex == old_del_choice_val || btnIndex >= del_choice->size())
 					btnIndex = 0;
 
-				//btn_choice->selectNone();
-				//btn_choice->removeIndex(delIndex);
-				//btn_choice->selectIndex(btnIndex);
+				btn_choice->selectNone();
+				btn_choice->removeIndex(delIndex);
+				btn_choice->selectIndex(btnIndex);
 			},
 			_("NO"), nullptr));
 	});
-	
+
 	systemConfiguration->addWithLabel(_("DELETE REMAP"), del_choice);	
 	
 }

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4246,12 +4246,12 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 			return;
 		
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
-			_("YES"), [mWindow, deleteOption, prefixName, &arr_joy_btn_names]
+			_("YES"), [mWindow, deleteOption, prefixName, arr_joy_btn_names]
 			{
 				//std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
 				int index = atoi(deleteOption->getSelected().c_str());
 
-				arr_joy_btn_names->erase(arr_joy_btn_names->begin() + index);
+				arr_joy_btn_names.erase(arr_joy_btn_names.begin() + index);
 
 				index++;
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4331,7 +4331,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 
 				int old_del_choice_val = delIndex;
 				del_choice->selectNone();
-				//del_choice->removeIndex(delIndex);
+				del_choice->removeIndex(delIndex);
 				del_choice->selectFirstItem();
 
 				int btnIndex = btn_choice->getSelectedIndex();
@@ -4339,7 +4339,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 					btnIndex = 0;
 
 				btn_choice->selectNone();
-				//btn_choice->removeIndex(delIndex);
+				btn_choice->removeIndex(delIndex);
 				btn_choice->selectIndex(btnIndex);
 			},
 			_("NO"), nullptr));

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4376,7 +4376,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 					SystemConf::getInstance()->get(configName + ".joy_btn_count") + " \n" +
 					SystemConf::getInstance()->get(configName + ".joy_btn_map_count") + " \n" +
 					SystemConf::getInstance()->get(configName + ".joy_btn_names") + " \n",
-					_("OK"), nullptr);
+					_("OK"), nullptr));
 				return;
 			}
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -5037,7 +5037,8 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 		return joy_btn_cfg;
 	}
 
-	int cfgIndex = atoi(SystemConf::getInstance()->get(configname + ".joy_btn_cfg").c_str());
+	int cfgIndex = joy_btn_cfg->getSelected();
+	//int cfgIndex = atoi(SystemConf::getInstance()->get(configname + ".joy_btn_cfg").c_str());
 	if (cfgIndex > joy_btn_recs.size())
 		cfgIndex = 0;
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4161,9 +4161,10 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		});
 	}
 	
-	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::joybtnremap))
+	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::joybtnremap) ||
+		systemData->getDefaultEmulator(currentEmulator))
 	{
-		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, systemData->getName());
+		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, currentCore);
 		systemConfiguration->addWithLabel(_("JOY BUTTON CFG"), joyBtn_choice);
 		systemConfiguration->addSaveFunc([configName, joyBtn_choice] {
 			if (!joyBtn_choice->getSelected().empty()) {
@@ -4749,11 +4750,11 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createNativeVideoReso
 	return emuelec_video_mode;
 }
 
-std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOptionList(Window *window, std::string configname, std::string systemName)
+std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOptionList(Window *window, std::string configname, std::string prefixName)
 {
 	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
 
-	int remapCount = atoi(SystemConf::getInstance()->get(systemName + ".joy_btn_count").c_str());
+	int remapCount = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_count").c_str());
 
 	if (remapCount == 0) {
 		joy_btn_cfg->add("auto", "0", true);
@@ -4762,7 +4763,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 
 	std::vector<std::string> joy_btn_recs;
 	for (int i=0; i < remapCount; ++i) {
-		std::string joyBtnName = SystemConf::getInstance()->get(systemName + ".joy_btn_name" + std::to_string(i));
+		std::string joyBtnName = SystemConf::getInstance()->get(prefixName + ".joy_btn_name" + std::to_string(i));
 		if (!joyBtnName.empty())
 			joy_btn_recs.push_back(joyBtnName);
 	}

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4285,22 +4285,24 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 	std::string sIndexes = SystemConf::getInstance()->get(prefixName + ".joy_btn_indexes");
 	std::vector<int> iIndexes(int_explode(sIndexes));
 
-	del_choice->add("NONE", "-1", true);
+	del_choice->add("NONE", "0", true);
 	int i = 1;
 	for (auto it = remap_names.cbegin(); it != remap_names.cend(); it++) {
 		del_choice->add(*it, std::to_string(i), false);
 		i++;
 	}
 
-	del_choice->setSelectedChangedCallback([mWindow, btn_choice, del_choice, prefixName, remap_names, iIndexes](std::string s) {
+	del_choice->setSelectedChangedCallback([mWindow, btn_choice, del_choice, prefixName, remap_names, iIndexes](std::string s) {		
 		int delIndex = del_choice->getSelectedIndex();
-		if (delIndex == 0)
+		if (delIndex <= 0)
 			return;
 
+		del_choice->selectFirstItem();
+
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
-			_("YES"), [mWindow, btn_choice, del_choice, prefixName, remap_names, iIndexes]
+			_("YES"), [mWindow, btn_choice, del_choice, prefixName, remap_names, iIndexes, delIndex]
 			{
-				int delIndex = del_choice->getSelectedIndex();
+				//int delIndex = del_choice->getSelectedIndex();
 				int delCfgIndex = (delIndex-1);
 
 				std::string sRemapNames = "";
@@ -4330,15 +4332,14 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				SystemConf::getInstance()->saveSystemConf();
 
 				int old_del_choice_val = delIndex;
-				del_choice->selectNone();
+				//del_choice->selectNone();
 				del_choice->removeIndex(delIndex);
-				del_choice->selectFirstItem();
 
 				int btnIndex = btn_choice->getSelectedIndex();
 				if (btnIndex == old_del_choice_val || btnIndex >= del_choice->size())
 					btnIndex = 0;
 
-				btn_choice->selectNone();
+				//btn_choice->selectNone();
 				btn_choice->removeIndex(delIndex);
 				btn_choice->selectIndex(btnIndex);
 			},

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4169,7 +4169,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
 		systemConfiguration->addWithLabel(_("JOY BUTTON CFG"), joyBtn_choice);
 		systemConfiguration->addSaveFunc([configName, joyBtn_choice] {
-			if (!joyBtn_choice->getSelected().empty() || joyBtn_choice->getSelected() != "0") {
+			if (!joyBtn_choice->getSelected().empty()) {
 				SystemConf::getInstance()->set(configName + ".joy_btn_cfg", joyBtn_choice->getSelected());
 				SystemConf::getInstance()->saveSystemConf();
 			}

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4136,30 +4136,33 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfigura
 {
 	std::vector<std::shared_ptr<OptionListComponent<std::string>>> remap_choice;
 
+	std::string btnNames = SystemConf::getInstance()->get(prefixName + ".joy_btns");
+	int btnCount = static_cast<int>(std::count(btnNames.begin(), btnNames.end(), ',')+1);
+
 	std::string remapNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_names");
 	int remapCount = static_cast<int>(std::count(remapNames.begin(), remapNames.end(), ',')+1);
 	
-	for (int index=0; index < remapCount; ++index)
+	for (int index=0; index < btnCount; ++index)
 	{		
 		auto remap = createJoyBtnRemapOptionList(mWindow, prefixName, index);
 		remap_choice.push_back(remap);
 		systemConfiguration->addWithLabel(_("JOY BUTTON ")+std::to_string(index), remap_choice[index]);
 	}
 
-	systemConfiguration->addSaveFunc([mWindow, remap_choice, del_choice, btn_choice, remapCount, prefixName, remapName, remapNames] {
+	systemConfiguration->addSaveFunc([mWindow, remap_choice, del_choice, btn_choice, remapCount, prefixName, remapName, remapNames, btnCount] {
 		int err = 0;
-		if (remapCount == 0)
+		if (btnCount == 0)
 			err = 1;
 
 		int j=0;
 		[&] {
-			for(int i=0; i < remapCount; ++i) {
+			for(int i=0; i < btnCount; ++i) {
 				int choice = atoi(remap_choice[i]->getSelected().c_str());
 				if (choice == -1) {
 					err=1;
 					break;
 				}
-				for(j=0; j < remapCount; ++j) {
+				for(j=0; j < btnCount; ++j) {
 					int choice2 = atoi(remap_choice[j]->getSelected().c_str());
 					if (choice2 == -1) {
 						err=1;
@@ -4188,7 +4191,7 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfigura
 			SystemConf::getInstance()->set(prefixName + ".joy_btn_names", names);
 
 			std::string joyRemap = "";
-			for(int i=0; i < remapCount; ++i)
+			for(int i=0; i < btnCount; ++i)
 			{
 				if (i > 0)
 					joyRemap += " ";
@@ -4231,7 +4234,10 @@ void GuiMenu::createBtnJoyCfgName(Window *mWindow, GuiSettings *systemConfigurat
 	auto updateVal = [mWindow, prefixName, btn_choice, del_choice](const std::string& newVal)
 	{
 		if (newVal.empty()) return;
-
+		if(newVal.find(',') != std::string::npos) {
+			mWindow->pushGui(new GuiMsgBox(mWindow, _("YOU CANNOT HAVE COMMAS IN REMAP NAME"), _("OK"), nullptr));
+		  return;
+		}
 		GuiSettings* systemConfiguration = new GuiSettings(mWindow, "CREATE REMAP");
 		GuiMenu::createBtnJoyCfgRemap(mWindow, systemConfiguration, btn_choice, del_choice, prefixName, newVal);
 		mWindow->pushGui(systemConfiguration);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4159,8 +4159,9 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfigura
 				joyRemap += " ";
 			joyRemap += remap_choice[i]->getSelected();
 		}
-		SystemConf::getInstance()->set(prefixName + ".joy_btn_order" + std::to_string(remapCount), joyRemap);
-	});		
+		SystemConf::getInstance()->set(prefixName + ".joy_btn_order" + std::to_string(count), joyRemap);
+		SystemConf::getInstance()->saveSystemConf();
+	});
 }
 
 void GuiMenu::createBtnJoyCfgName(Window *mWindow, GuiSettings *mSystemConfiguration, std::string prefixName)
@@ -4190,6 +4191,8 @@ void GuiMenu::createBtnJoyCfgName(Window *mWindow, GuiSettings *mSystemConfigura
 
 	row.makeAcceptInputHandler([mWindow, createText, updateVal]
 	{
+		if (updateVal.empty()) return;
+
 		if (Settings::getInstance()->getBool("UseOSK"))
 			mWindow->pushGui(new GuiTextEditPopupKeyboard(mWindow, _("REMAP NAME"), "", updateVal, false));
 		else

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4160,6 +4160,17 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 			SystemConf::getInstance()->saveSystemConf();
 		});
 	}
+	
+	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::joybtnremap))
+	{
+		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, currentEmulator);
+		systemConfiguration->addWithLabel(_("JOY BUTTON CFG"), joyBtn_choice);
+		systemConfiguration->addSaveFunc([configName, joyBtn_choice] {
+			SystemConf::getInstance()->set(configName + ".joy_btn_cfg", joyBtn_choice->getSelected());
+			SystemConf::getInstance()->saveSystemConf();
+		});
+	}
+	
 #endif 
 
 	// Screen ratio choice
@@ -4735,6 +4746,27 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createNativeVideoReso
 
 	return emuelec_video_mode;
 }
+
+std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOptionList(Window *window, std::string configname, std::string emulator)
+{
+	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
+	int index = SystemConf::getInstance()->get(emulator + ".joy_btn_count");
+	
+	std::vector<std::string> joy_btn_names;
+	for (int i=0; i < index; ++i)
+		joy_btn_names.push_back(SystemConf::getInstance()->get(emulator + ".joy_btn_name"+i));
+
+	std::string index = SystemConf::getInstance()->get(configname + ".joy_btn_cfg");
+	if (index.empty())
+		index = "auto";
+
+	for (auto it = joy_btn_names.cbegin(); it != joy_btn_names.cend(); it++) {
+		joy_btn_cfg->add(*it, *it, index == *it);
+	}
+
+	return joy_btn_cfg;
+}
+
 #endif 
 
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4274,7 +4274,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		i++;
 	}
 	
-	del_choice->setSelectedChangedCallback([mWindow, del_choice, prefixName, arr_joy_btn_names, btn_choice, iIndexes] (std::string s) {
+	del_choice->setSelectedChangedCallback([mWindow, btn_choice, del_choice, prefixName, arr_joy_btn_names, iIndexes] (std::string s) {
 		int index = del_choice->getSelectedIndex();
 		if (index == 0)
 			return;
@@ -4291,7 +4291,8 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				tIndexes.erase(tIndexes.begin() + delIndex);
 
 				std::string sRemapNames = "";
-				for(int i=0; i < tNames.size(); ++i)
+				int i;
+				for(i=0; i < tNames.size(); ++i)
 				{
 					if (i > 0)
 						sRemapNames += ",";
@@ -4301,7 +4302,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				SystemConf::getInstance()->set(prefixName + ".joy_btn_order"+std::to_string(remapIndex), "");
 
 				std::string sIndexes = "";
-				for(int i=0; i < tIndexes.size(); ++i)
+				for(i=0; i < tIndexes.size(); ++i)
 				{
 					if (i > 0)
 						sIndexes += ",";
@@ -4310,7 +4311,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				SystemConf::getInstance()->set(prefixName + ".joy_btn_indexes", sIndexes);
 
 				SystemConf::getInstance()->saveSystemConf();
-				
+
 				std::string tName = del_choice->getSelectedName();
 
 				bool btn_match = del_choice->getSelectedIndex() == btn_choice->getSelectedIndex();

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4285,7 +4285,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
 				int delIndex = (del_choice->getSelectedIndex()-1);
 
-				std::string tName = l_arr_joy_btn_names[delIndex];
+				std::string tName = del_choice->getSelectedName();
 
 				l_arr_joy_btn_names.erase(l_arr_joy_btn_names.begin() + delIndex);
 // TODO indexes are screwing up.

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -5017,17 +5017,15 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 {
 	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
 
-	int remapCount = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_count").c_str());
+	std::string joyBtnNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_names");
+	std::vector<std::string> joy_btn_recs(explode(joyBtnNames));
+
+	int remapCount = joy_btn_recs.size();
 
 	if (prefixName == "auto" || prefixName.empty() || remapCount == 0) {
 		joy_btn_cfg->add("auto", "0", true);
 		return joy_btn_cfg;
 	}
-
-	std::string joyBtnNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_names");
-	std::vector<std::string> joy_btn_recs(explode(joyBtnNames));
-
-	//int nameCount=remapCount+1;
 
 	int cfgIndex = atoi(SystemConf::getInstance()->get(configname + ".joy_btn_cfg").c_str());
 	if (cfgIndex > joy_btn_recs.size())

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4268,10 +4268,10 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 	std::vector<int> iIndexes(int_explode(sIndexes));
 
 	del_choice->add("NONE", "-1", true);
-	int index = 0;
+	int i = 0;
 	for (auto it = arr_joy_btn_names.cbegin(); it != arr_joy_btn_names.cend(); it++) {
-		del_choice->add(*it, std::to_string(joy_btn_indexes[i]), false);
-		index++;
+		del_choice->add(*it, std::to_string(iIndexes[i]), false);
+		i++;
 	}
 	
 	del_choice->setSelectedChangedCallback([mWindow, del_choice, prefixName, arr_joy_btn_names, btn_choice, iIndexes] (std::string s) {
@@ -4289,8 +4289,10 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 
 				l_arr_joy_btn_names.erase(l_arr_joy_btn_names.begin() + delIndex);
 // TODO indexes are screwing up.
-				int remapIndex = iIndexes[delIndex];
-				iIndexes.erase(iIndexes.begin() + delIndex);
+
+				std::vector<int> tIndexes(iIndexes);
+				int remapIndex = tIndexes[delIndex];
+				tIndexes.erase(tIndexes.begin() + delIndex);
 
 				std::string remapNames = "";
 				for(int i=0; i < l_arr_joy_btn_names.size(); ++i)
@@ -4303,11 +4305,11 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				SystemConf::getInstance()->set(prefixName + ".joy_btn_order"+std::to_string(remapIndex), "");
 
 				std::string sIndexes = "";
-				for(int i=0; i < iIndexes.size(); ++i)
+				for(int i=0; i < tIndexes.size(); ++i)
 				{
 					if (i > 0)
 						sIndexes += ",";
-					sIndexes += std::to_string(iIndexes[i]);
+					sIndexes += std::to_string(tIndexes[i]);
 				}
 				SystemConf::getInstance()->set(prefixName + ".joy_btn_indexes", sIndexes);
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4292,7 +4292,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		i++;
 	}
 
-	del_choice->setSelectedChangedCallback([mWindow, &btn_choice, &del_choice, prefixName, arr_btn_names, iIndexes](std::string s) {
+	del_choice->setSelectedChangedCallback([mWindow, btn_choice, del_choice, prefixName, arr_btn_names, iIndexes](std::string s) {
 		int delIndex = del_choice->getSelectedIndex();
 		if (delIndex == 0)
 			return;
@@ -4303,11 +4303,11 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				
 				std::vector<std::string> tNames(arr_btn_names);
 				int delCfgIndex = (delIndex-1);
-				tNames.erase(tNames.cbegin() + delIndex);
+				tNames.erase(tNames.begin() + delIndex);
 
 				std::vector<int> tIndexes(iIndexes);
 				int remapIndex = tIndexes[delIndex];
-				tIndexes.erase(tIndexes.cbegin() + delIndex);
+				tIndexes.erase(tIndexes.begin() + delIndex);
 
 				std::string sRemapNames = "";
 				int i;
@@ -4333,7 +4333,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 
 				int old_del_choice_val = delIndex;
 				del_choice->selectNone();
-				del_choice->removeIndex(delIndex);
+				//del_choice->removeIndex(delIndex);
 				del_choice->selectFirstItem();
 
 				int btnIndex = btn_choice->getSelectedIndex();
@@ -4341,7 +4341,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 					btnIndex = 0;
 
 				btn_choice->selectNone();
-				btn_choice->removeIndex(delIndex);
+				//btn_choice->removeIndex(delIndex);
 				btn_choice->selectIndex(btnIndex);
 			},
 			_("NO"), nullptr));

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4162,7 +4162,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		});
 	}
 
-	std::string tEmulator = (systemData->getEmulator().empty() ? currentEmulator : systemData->getEmulator());
+	std::string tEmulator = (currentEmulator == "auto") ? systemData->getEmulator(true) : currentEmulator);
 	if (systemData->isFeatureSupported(tEmulator, currentCore, EmulatorFeatures::joybtnremap))
 	{
 		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4752,19 +4752,20 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
 	int index = std::stoi(SystemConf::getInstance()->get(emulator + ".joy_btn_count"));
 	
-	std::vector<std::pair<std::string,std::string>> joy_btn_recs;
+	std::vector<std::string> joy_btn_recs;
 	for (int i=0; i < index; ++i) {
-		std::string name = SystemConf::getInstance()->get(emulator + ".joy_btn_name" + std::to_string(i));
-		std::string val = SystemConf::getInstance()->get(emulator + ".joy_btn_order" + std::to_string(i));
-		joy_btn_recs.push_back( std::make_pair(name,val));
+		joy_btn_recs.push_back(SystemConf::getInstance()->get(emulator + ".joy_btn_name" + std::to_string(i)));
 	}
 	
-	std::string sIndex = SystemConf::getInstance()->get(configname + ".joy_btn_cfg");
-	if (sIndex.empty())
-		sIndex = "auto";
+	std::string choice = SystemConf::getInstance()->get(configname + ".joy_btn_cfg");
+	int cindex = 0;
+	if (!choice.empty())
+		cindex = std::stoi(choice);
 
+	int i = 0;
 	for (auto it = joy_btn_recs.cbegin(); it != joy_btn_recs.cend(); it++) {
-		joy_btn_cfg->add(it->first, it->second, sIndex == it->first);
+		joy_btn_cfg->add(*it->first, i, cindex == i);
+		i++;
 	}
 
 	return joy_btn_cfg;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4365,13 +4365,14 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		tEmulator = systemData->getEmulator(true);
 	if (!tEmulator.empty() && systemData->isFeatureSupported(tEmulator, currentCore, EmulatorFeatures::joybtnremap))
 	{
-		[&] {
+		[&, mWindow, systemConfiguration, configName, tEmulator] {
 			if (SystemConf::getInstance()->get(configName + ".joy_btns").empty() ||
 					SystemConf::getInstance()->get(configName + ".joy_btn_count").empty() ||
 					SystemConf::getInstance()->get(configName + ".joy_btn_map_count").empty() ||
 					SystemConf::getInstance()->get(configName + ".joy_btn_names").empty())
 			{
 				mWindow->pushGui(new GuiMsgBox(mWindow, 
+					configName + " /n" +
 					SystemConf::getInstance()->get(configName + ".joy_btns") + " \n" +
 					SystemConf::getInstance()->get(configName + ".joy_btn_count") + " \n" +
 					SystemConf::getInstance()->get(configName + ".joy_btn_map_count") + " \n" +

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4183,7 +4183,7 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfigura
 		}
 		
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO CREATE THE REMAP?"),
-			_("YES"), [mWindow, remap_choice, del_choice, btn_choice, remapCount, prefixName, remapName, remapNames]
+			_("YES"), [mWindow, remap_choice, del_choice, btn_choice, remapCount, prefixName, remapName, remapNames, btnCount]
 		{
 			int count = remapCount+1;
 
@@ -4191,8 +4191,7 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfigura
 			SystemConf::getInstance()->set(prefixName + ".joy_btn_names", names);
 
 			std::string joyRemap = "";
-			int size = remap_choice[0]->size();
-			for(int i=0; i < size; ++i) {
+			for(int i=0; i < btnCount; ++i) {
 				if (i > 0)
 					joyRemap += " ";
 				joyRemap += remap_choice[i]->getSelected();
@@ -4254,7 +4253,6 @@ void GuiMenu::createBtnJoyCfgName(Window *mWindow, GuiSettings *systemConfigurat
 	systemConfiguration->addRow(row);
 }
 
-// TODO - Sometimes crashes ES when removing from middle.
 void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 	 std::shared_ptr<OptionListComponent<std::string>> btn_choice,
 	 std::shared_ptr<OptionListComponent<std::string>> del_choice,

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -5037,7 +5037,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 		return joy_btn_cfg;
 	}
 
-	int cfgIndex = joy_btn_cfg->getSelected();
+	int cfgIndex = atoi(joy_btn_cfg->getSelected().c_str());
 	//int cfgIndex = atoi(SystemConf::getInstance()->get(configname + ".joy_btn_cfg").c_str());
 	if (cfgIndex > joy_btn_recs.size())
 		cfgIndex = 0;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4749,21 +4749,21 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createNativeVideoReso
 
 std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOptionList(Window *window, std::string configname, std::string emulator)
 {
-	SystemConf::getInstance()->set(emulator + ".test123");
+	SystemConf::getInstance()->set(emulator + ".test123", "blah");
 	
 	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
 	std::string sRemapCount = SystemConf::getInstance()->get(emulator + ".joy_btn_count");
 	int remapCount = 0;
-	if (!remapCount.empty())
-		remapCount = std::stoi(remapCount);
-	
+	if (!sRemapCount.empty())
+		remapCount = std::stoi(sRemapCount);
+
 	if (remapCount == 0) {
 		joy_btn_cfg->add("auto", 0, true);
 		return joy_btn_cfg;
 	}
 	
 	std::vector<std::string> joy_btn_recs;
-	for (int i=0; i < index; ++i) {
+	for (int i=0; i < remapCount; ++i) {
 		joy_btn_recs.push_back(SystemConf::getInstance()->get(emulator + ".joy_btn_name" + std::to_string(i)));
 	}
 	

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4163,7 +4163,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::joybtnremap))
 	{
-		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, currentCore);
+		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, systemData->getName());
 		systemConfiguration->addWithLabel(_("JOY BUTTON CFG"), joyBtn_choice);
 		systemConfiguration->addSaveFunc([configName, joyBtn_choice] {
 			if (!joyBtn_choice->getSelected().empty()) {
@@ -4749,12 +4749,12 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createNativeVideoReso
 	return emuelec_video_mode;
 }
 
-std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOptionList(Window *window, std::string configname, std::string core)
+std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOptionList(Window *window, std::string configname, std::string systemName)
 {
 	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
 
 	std::string enabled = SystemConf::getInstance()->get("advmame_joy_remap");
-	SystemConf::getInstance()->set(core + ".blah123", "blah123");
+	SystemConf::getInstance()->set(systemName + ".blah123", "blah123");
 	
 	std::string sRemapCount = SystemConf::getInstance()->get(core + ".joy_btn_count");
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4130,15 +4130,15 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnRemapOpti
 	return joy_btn_cfg;
 }
 
-// TODO - Send joy_btn_cfg_option and and del_btn_option to this function so they can auto update when a new remap created.
-
 void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfiguration,
 	std::shared_ptr<OptionListComponent<std::string>> btn_choice, std::shared_ptr<OptionListComponent<std::string>> del_choice,
 	std::string prefixName, std::string remapName)
 {
 	std::vector<std::shared_ptr<OptionListComponent<std::string>>> remap_choice;
+
+	std::string remapNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_names");
+	int remapCount = static_cast<int>(std::count(remapNames.begin(), remapNames.end(), ',')+1);
 	
-	int remapCount = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_count").c_str());
 	for (int index=0; index < remapCount; ++index)
 	{		
 		auto remap = createJoyBtnRemapOptionList(mWindow, prefixName, index);
@@ -4148,8 +4148,6 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfigura
 
 	systemConfiguration->addSaveFunc([mWindow, remap_choice, del_choice, btn_choice, remapCount, prefixName, remapName] {
 		int err = 0;
-		std::string remapNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_names");
-		int remapCount = static_cast<int>(std::count(remapNames.begin(), remapNames.end(), ',')+1);
 		if (remapCount == 0)
 			err = 1;
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4168,7 +4168,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, systemData->getEmulator());
 		systemConfiguration->addWithLabel(_("JOY BUTTON CFG"), joyBtn_choice);
 		systemConfiguration->addSaveFunc([configName, joyBtn_choice] {
-			if (!joyBtn_choice->getSelected().empty()) {
+			if (!joyBtn_choice->getSelected().empty() || joyBtn_choice->getSelected() != "0") {
 				SystemConf::getInstance()->set(configName + ".joy_btn_cfg", joyBtn_choice->getSelected());
 				SystemConf::getInstance()->saveSystemConf();
 			}

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4240,13 +4240,13 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		index++;
 	}
 	
-	deleteOption->setSelectedChangedCallback([mWindow, deleteOption, prefixName, &arr_joy_btn_names] (std::string s) {
+	deleteOption->setSelectedChangedCallback([mWindow, deleteOption, prefixName, arr_joy_btn_names] (std::string s) {
 		int index = atoi(deleteOption->getSelected().c_str());
 		if (index == -1)
 			return;
 		
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
-			_("YES"), [&, mWindow, deleteOption, prefixName, &arr_joy_btn_names]
+			_("YES"), [mWindow, deleteOption, prefixName, &arr_joy_btn_names]
 			{
 				//std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
 				int index = atoi(deleteOption->getSelected().c_str());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4157,10 +4157,8 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		auto videoNativeResolutionMode_choice = createNativeVideoResolutionModeOptionList(mWindow, configName);
 		systemConfiguration->addWithLabel(_("NATIVE VIDEO"), videoNativeResolutionMode_choice);
 		systemConfiguration->addSaveFunc([configName, videoNativeResolutionMode_choice] {
-			if (videoNativeResolutionMode_choice->changed()) {
 				SystemConf::getInstance()->set(configName + ".nativevideo", videoNativeResolutionMode_choice->getSelected());
 				SystemConf::getInstance()->saveSystemConf();
-			}
 		});
 	}
 
@@ -4173,10 +4171,8 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
 		systemConfiguration->addWithLabel(_("JOY BUTTON CFG"), joyBtn_choice);
 		systemConfiguration->addSaveFunc([configName, joyBtn_choice] {
-			if (joyBtn_choice->changed()) {
 				SystemConf::getInstance()->set(configName + ".joy_btn_cfg", joyBtn_choice->getSelected());
 				SystemConf::getInstance()->saveSystemConf();
-			}
 		});
 	}
 	

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4370,8 +4370,16 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 					SystemConf::getInstance()->get(configName + ".joy_btn_count").empty() ||
 					SystemConf::getInstance()->get(configName + ".joy_btn_map_count").empty() ||
 					SystemConf::getInstance()->get(configName + ".joy_btn_names").empty())
+			{
+				mWindow->pushGui(new GuiMsgBox(mWindow, 
+					SystemConf::getInstance()->get(configName + ".joy_btns") + " \n" +
+					SystemConf::getInstance()->get(configName + ".joy_btn_count") + " \n" +
+					SystemConf::getInstance()->get(configName + ".joy_btn_map_count") + " \n" +
+					SystemConf::getInstance()->get(configName + ".joy_btn_names") + " \n",
+					_("OK"), nullptr);
 				return;
-			
+			}
+
 			auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
 			systemConfiguration->addWithLabel(_("BUTTON REMAP"), joyBtn_choice);
 			systemConfiguration->addSaveFunc([mWindow, configName, joyBtn_choice] {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4240,7 +4240,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		index++;
 	}
 
-	std::function<void()> delFunc([&] {
+	std::function<void()> delFunc = [&] {
 		int index = atoi(deleteOption->getSelected().c_str());
 		if (index == -1)
 			return;
@@ -4272,7 +4272,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				SystemConf::getInstance()->saveSystemConf();			
 			}, 
 			_("NO"), nullptr));
-	});
+	};
 	
 	systemConfiguration->addWithLabel(_("DELETE REMAP"), deleteOption, delFunc, "", false);	
 	

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4183,7 +4183,7 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfigura
 		}
 		
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO CREATE THE REMAP?"),
-			_("YES"), [mWindow, remap_choice, del_choice, btn_choice, remapCount, prefixName, remapName, remapNames]
+			_("YES"), [mWindow, remap_choice, del_choice, btn_choice, remapCount, prefixName, remapName, remapNames, btnCount]
 		{
 			int count = remapCount+1;
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4764,7 +4764,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 
 	int i = 0;
 	for (auto it = joy_btn_recs.cbegin(); it != joy_btn_recs.cend(); it++) {
-		joy_btn_cfg->add(*it, i, cindex == i);
+		joy_btn_cfg->add(*it, std::to_string(i), cindex == i);
 		i++;
 	}
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -5048,14 +5048,12 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createNativeVideoReso
 
 std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOptionList(Window *window, std::string configname, std::string prefixName)
 {
-	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
+	auto btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
 
 	std::string btnNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_names");
 	std::vector<std::string> btn_names(explode(btnNames));
 
-	int remapCount = joy_btn_recs.size();
-
-	if (prefixName == "auto" || prefixName.empty() || remapCount == 0) {
+	if (prefixName == "auto" || prefixName.empty() || btn_names.size() == 0) {
 		joy_btn_cfg->add("auto", "0", true);
 		return joy_btn_cfg;
 	}
@@ -5065,12 +5063,12 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 		cfgIndex = 0;
 
 	int i = 1;
-	joy_btn_cfg->add("auto", "0", cfgIndex == 0);
+	btn_cfg->add("auto", "0", cfgIndex == 0);
 	for (auto it = btn_names.cbegin(); it != btn_names.cend(); it++) {
-		joy_btn_cfg->add(*it, std::to_string(i), cfgIndex == i);
+		btn_cfg->add(*it, std::to_string(i), cfgIndex == i);
 		i++;
 	}
-	return joy_btn_cfg;
+	return btn_cfg;
 }
 
 #endif 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4332,16 +4332,16 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				SystemConf::getInstance()->saveSystemConf();
 
 				int old_del_choice_val = delIndex;
-				del_choice->selectNone();
-				del_choice->removeIndex(delIndex);
+				//del_choice->selectNone();
+				//del_choice->removeIndex(delIndex);
 				//del_choice->selectFirstItem();
 
 				int btnIndex = btn_choice->getSelectedIndex();
 				if (btnIndex == old_del_choice_val || btnIndex >= del_choice->size())
 					btnIndex = 0;
 
-				btn_choice->selectNone();
-				btn_choice->removeIndex(delIndex);
+				//btn_choice->selectNone();
+				//btn_choice->removeIndex(delIndex);
 				//btn_choice->selectIndex(btnIndex);
 			},
 			_("NO"), nullptr));

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4297,10 +4297,8 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		int index = del_choice->getSelectedIndex();
 		if (index == 0)
 			return;
-		int delIndex = del_choice->getSelectedIndex();
-		SystemConf::getInstance()->set(prefixName + ".selected", std::to_string(delIndex));
-		SystemConf::getInstance()->set(prefixName + ".value", s);
-		return;
+
+		int delIndex = atoi(s.c_str());
 		
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
 			_("YES"), [mWindow, btn_choice, del_choice, prefixName, arr_btn_names, iIndexes, delIndex]

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4756,8 +4756,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 	for (int i=0; i < index; ++i) {
 		std::string name = SystemConf::getInstance()->get(emulator + ".joy_btn_name" + std::tostring(i));
 		std::string val = SystemConf::getInstance()->get(emulator + ".joy_btn_order" + std::tostring(i));
-		std::pair<std::string,std::string> rec{name,val};
-		joy_btn_recs.push_back(rec);
+		joy_btn_recs.push_back( std::make_pair(name,val));
 	}
 	
 	std::string sIndex = SystemConf::getInstance()->get(configname + ".joy_btn_cfg");

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4182,6 +4182,7 @@ void GuiMenu::createBtnJoyCfgName(Window *mWindow, GuiSettings *mSystemConfigura
 	{
 		GuiSettings* systemConfiguration = new GuiSettings(mWindow, "CREATE REMAP");
 		GuiMenu::createBtnJoyCfgRemap(mWindow, systemConfiguration, prefixName, newVal);
+		mWindow->pushGui(systemConfiguration);
 	};
 
 	row.makeAcceptInputHandler([mWindow, createText, updateVal]

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4084,7 +4084,7 @@ void GuiMenu::popGameConfigurationGui(Window* mWindow, FileData* fileData)
 // TODO 
 
 #ifdef _ENABLEEMUELEC
-void GuiMenu::createJoyBtnCfgOptionList(Window *mWindow, std::string title)
+void GuiMenu::createBtnJoyCfg(Window *mWindow, std::string title)
 {
 	GuiSettings* systemConfiguration = new GuiSettings(mWindow, title.c_str());
 
@@ -4098,7 +4098,7 @@ void GuiMenu::createJoyBtnCfgOptionList(Window *mWindow, std::string title)
 	row.addElement(mTextRemap, true);
 
 
-	auto updateVal = [this](const std::string& newVal)
+	auto updateVal = [mTextRemap](const std::string& newVal)
 	{
 		mTextRemap->setValue(Utils::String::toUpper(newVal));
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4754,7 +4754,6 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
 
 	std::string enabled = SystemConf::getInstance()->get("advmame_joy_remap");
-	SystemConf::getInstance()->set(core + ".blah123", "blah123");
 	
 	std::string sRemapCount = SystemConf::getInstance()->get(core + ".joy_btn_count");
 
@@ -4789,7 +4788,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 	return joy_btn_cfg;
 }
 
-#endif 
+#endif
 
 
 std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createVideoResolutionModeOptionList(Window *window, std::string configname)

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4755,7 +4755,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 
 	int enabled = atoi(SystemConf::getInstance()->get("advmame_joy_remap").c_str());
 	
-	int remapCount = atoi(SystemConf::getInstance()->get(systemName + ".joy_btn_count").c_str();
+	int remapCount = atoi(SystemConf::getInstance()->get(systemName + ".joy_btn_count").c_str());
 
 	if (enabled != 1 || remapCount == 0) {
 		joy_btn_cfg->add("auto", "0", true);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4281,27 +4281,27 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 {
 
 	std::string remapNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_names");
-	std::vector<std::string> arr_joy_btn_names(explode(remapNames));
+	std::vector<std::string> arr_btn_names(explode(remapNames));
 
 	std::string sIndexes = SystemConf::getInstance()->get(prefixName + ".joy_btn_indexes");
 	std::vector<int> iIndexes(int_explode(sIndexes));
 
 	del_choice->add("NONE", "-1", true);
 	int i = 0;
-	for (auto it = arr_joy_btn_names.cbegin(); it != arr_joy_btn_names.cend(); it++) {
+	for (auto it = arr_btn_names.cbegin(); it != arr_btn_names.cend(); it++) {
 		del_choice->add(*it, std::to_string(iIndexes[i]), false);
 		i++;
 	}
 	
-	del_choice->setSelectedChangedCallback([mWindow, btn_choice, del_choice, prefixName, arr_joy_btn_names, iIndexes] (std::string s) {
+	systemConfiguration->addSaveFunc([mWindow, btn_choice, del_choice, prefixName, arr_btn_names, iIndexes] {
 		int index = del_choice->getSelectedIndex();
 		if (index == 0)
 			return;
 		
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
-			_("YES"), [mWindow, del_choice, prefixName, arr_joy_btn_names, btn_choice, iIndexes]
+			_("YES"), [mWindow, btn_choice, del_choice, prefixName, arr_btn_names, iIndexes]
 			{
-				std::vector<std::string> tNames(arr_joy_btn_names);
+				std::vector<std::string> tNames(arr_btn_names);
 				int delIndex = (del_choice->getSelectedIndex()-1);
 				tNames.erase(tNames.begin() + delIndex);
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4333,12 +4333,13 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 
 				std::string tName = del_choice->getSelectedName();
 
-				bool btn_match = del_choice->getSelectedIndex() == btn_choice->getSelectedIndex();
+				int old_del_choice_val = del_choice->getSelectedIndex();
 				del_choice->selectFirstItem();
 				del_choice->remove(tName);
 
 				int btn_index = btn_choice->getSelectedIndex();
-				if (btn_index >= (btn_choice->size()-1) || btn_match)
+
+				if (btn_index == old_del_choice_val)
 					btn_choice->selectFirstItem();
 				btn_choice->remove(tName);
 			},
@@ -4448,7 +4449,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 			auto btn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
 			auto del_choice = std::make_shared<OptionListComponent<std::string>>(mWindow, _("DELETE REMAP"), false);
 			systemConfiguration->addWithLabel(_("BUTTON REMAP"), btn_choice);
-			btn_choice->setSelectedChangedCallback([configName, btn_choice](std::string s) {
+			btn_choice->addSaveFunc([configName, btn_choice] {
 				if (btn_choice->getSelectedIndex() >= 0)
 				{
 					SystemConf::getInstance()->set(configName + ".joy_btn_cfg", btn_choice->getSelected());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4297,7 +4297,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		int index = del_choice->getSelectedIndex();
 		if (index == 0)
 			return;
-		int delIndex = this->getSelectedIndex();
+		int delIndex = del_choice->getSelectedIndex();
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
 			_("YES"), [mWindow, btn_choice, del_choice, prefixName, arr_btn_names, iIndexes, delIndex]
 			{

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4301,32 +4301,29 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 			_("YES"), [mWindow, btn_choice, del_choice, prefixName, remap_names, iIndexes]
 			{
 				int delIndex = del_choice->getSelectedIndex();
-
-				std::vector<std::string> tNames = remap_names;
 				int delCfgIndex = (delIndex-1);
-				tNames.erase(tNames.begin() + delCfgIndex);
-
-				std::vector<int> tIndexes = iIndexes;
-				//int remapIndex = tIndexes[delIndex];
-				tIndexes.erase(tIndexes.begin() + delCfgIndex);
 
 				std::string sRemapNames = "";
 				int i;
-				for(i=0; i < tNames.size(); ++i)
+				for(i=0; i < remap_names.size(); ++i)
 				{
+					if (i == delCfgIndex)
+						continue;					
 					if (i > 0)
 						sRemapNames += ",";
-					sRemapNames += tNames[i];
+					sRemapNames += remap_names[i];
 				}
 				SystemConf::getInstance()->set(prefixName + ".joy_btn_names", sRemapNames);
 				//SystemConf::getInstance()->set(prefixName + ".joy_btn_order"+std::to_string(remapIndex), "");
 
 				std::string sIndexes = "";
-				for(i=0; i < tIndexes.size(); ++i)
+				for(i=0; i < iIndexes.size(); ++i)
 				{
+					if (i == delCfgIndex)
+						continue;
 					if (i > 0)
 						sIndexes += ",";
-					sIndexes += std::to_string(tIndexes[i]);
+					sIndexes += std::to_string(iIndexes[i]);
 				}
 				SystemConf::getInstance()->set(prefixName + ".joy_btn_indexes", sIndexes);
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4350,7 +4350,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
 		systemConfiguration->addWithLabel(_("BUTTON REMAP"), joyBtn_choice);
 		systemConfiguration->addSaveFunc([mWindow, configName, joyBtn_choice] {
-			if (!joyBtn_choice->getSelected())
+			if (joyBtn_choice->getSelectedIndex() >= 0)
 			{
 				SystemConf::getInstance()->set(configName + ".joy_btn_cfg", joyBtn_choice->getSelected());
 				SystemConf::getInstance()->saveSystemConf();

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4162,10 +4162,10 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		});
 	}
 
-	std::string tEmulator = (currentEmulator == "auto") ? systemData->getEmulator(true) : currentEmulator;
-	if (systemData->isFeatureSupported(tEmulator, currentCore, EmulatorFeatures::joybtnremap))
+	//std::string tEmulator = (currentEmulator == "auto") ? systemData->getEmulator(true) : currentEmulator;
+	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::joybtnremap))
 	{
-		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
+		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, currentEmulator);
 		systemConfiguration->addWithLabel(_("JOY BUTTON CFG"), joyBtn_choice);
 		systemConfiguration->addSaveFunc([configName, joyBtn_choice] {
 			if (!joyBtn_choice->getSelected().empty()) {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4161,8 +4161,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		});
 	}
 	
-	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::joybtnremap) ||
-		systemData->getDefaultEmulator(currentEmulator))
+	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::joybtnremap))
 	{
 		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, currentCore);
 		systemConfiguration->addWithLabel(_("JOY BUTTON CFG"), joyBtn_choice);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4239,8 +4239,8 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		deleteOption->add(*it, std::to_string(index), false);
 		index++;
 	}
-
-	auto delFunc = [&] {
+	
+	deleteOption->setSelectedChangedCallback([&] {
 		int index = atoi(deleteOption->getSelected().c_str());
 		if (index == -1)
 			return;
@@ -4272,11 +4272,11 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				SystemConf::getInstance()->saveSystemConf();			
 			}, 
 			_("NO"), nullptr));
-	};
+	});
 	
-	systemConfiguration->addWithLabel(_("DELETE REMAP"), deleteOption, delFunc, "", false);	
+	systemConfiguration->addWithLabel(_("DELETE REMAP"), deleteOption);	
 	
-	deleteOption->setSelectedChangedCallback(delFunc);
+	
 
 	/*systemConfiguration->addSaveFunc([mWindow, deleteOption, prefixName, arr_joy_btn_names] {
 		int index = atoi(deleteOption->getSelected().c_str());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4240,7 +4240,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		index++;
 	}
 
-	std::function<void()> delFunc([mWindow, deleteOption, prefixName, arr_joy_btn_names] {
+	std::function<void()> delFunc([&] {
 		int index = atoi(deleteOption->getSelected().c_str());
 		if (index == -1)
 			return;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4227,7 +4227,8 @@ void GuiMenu::createBtnJoyCfgName(Window *mWindow, GuiSettings *systemConfigurat
 	systemConfiguration->addRow(row);
 }
 
-void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration, std::string prefixName) {
+void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
+	 std::shared_ptr<OptionListComponent<std::string>> joyBtn_choice, std::string prefixName) {
 	auto deleteOption = std::make_shared<OptionListComponent<std::string>>(mWindow, _("DELETE REMAP"), false);
 	
 	std::string remapNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_names");
@@ -4240,13 +4241,13 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		index++;
 	}
 	
-	deleteOption->setSelectedChangedCallback([mWindow, deleteOption, prefixName, arr_joy_btn_names] (std::string s) {
+	deleteOption->setSelectedChangedCallback([mWindow, deleteOption, prefixName, arr_joy_btn_names, joyBtn_choice] (std::string s) {
 		int index = atoi(deleteOption->getSelected().c_str());
 		if (index == -1)
 			return;
 		
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
-			_("YES"), [mWindow, deleteOption, prefixName, arr_joy_btn_names]
+			_("YES"), [mWindow, deleteOption, prefixName, arr_joy_btn_names, joyBtn_choice]
 			{
 				std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
 				int index = atoi(deleteOption->getSelected().c_str());
@@ -4275,47 +4276,17 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 
 				deleteOption->remove(tName);
 				deleteOption->selectFirstItem();
+				
+				int joyBtn_index = atoi(joyBtn_choice->getSelected().c_str());
+				if (joyBtn_index == index)
+					joyBtn_choice->selectFirstItem();
+				joyBtn_choice->remove(tName);
 			}, 
 			_("NO"), nullptr));
 	});
 	
 	systemConfiguration->addWithLabel(_("DELETE REMAP"), deleteOption);	
 	
-	
-
-	/*systemConfiguration->addSaveFunc([mWindow, deleteOption, prefixName, arr_joy_btn_names] {
-		int index = atoi(deleteOption->getSelected().c_str());
-		if (index == -1)
-			return;
-		
-		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
-			_("YES"), [mWindow, deleteOption, prefixName, arr_joy_btn_names]
-			{
-				std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
-				int index = atoi(deleteOption->getSelected().c_str());
-
-				l_arr_joy_btn_names.erase(l_arr_joy_btn_names.begin() + index);
-
-				index++;
-
-				std::string remapNames = "";
-				for(int i=0; i < l_arr_joy_btn_names.size(); ++i)
-				{
-					if (i > 0)
-						remapNames += ",";
-					remapNames += l_arr_joy_btn_names[i];
-				}		
-				SystemConf::getInstance()->set(prefixName + ".joy_btn_names", remapNames);
-				SystemConf::getInstance()->set(prefixName + ".joy_btn_order"+std::to_string(index), "");
-				
-				int count = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_map_count").c_str());
-				if (count > 0)
-					SystemConf::getInstance()->set(prefixName + ".joy_btn_map_count", std::to_string(--count));
-				
-				SystemConf::getInstance()->saveSystemConf();			
-			}, 
-			_("NO"), nullptr));
-	});*/
 }
 
 #endif
@@ -4427,7 +4398,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 			if (fileData == nullptr)
 			{
 				GuiMenu::createBtnJoyCfgName(mWindow, systemConfiguration, tEmulator);
-				GuiMenu::deleteBtnJoyCfg(mWindow, systemConfiguration, tEmulator);
+				GuiMenu::deleteBtnJoyCfg(mWindow, systemConfiguration, joyBtn_choice, tEmulator);
 			}
 		}();
 	}

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4752,7 +4752,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 	SystemConf::getInstance()->set(emulator + ".test123", "blah");
 	
 	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
-	std::string sRemapCount = SystemConf::getInstance()->get(emulator + ".joy_btn_count");
+	/*std::string sRemapCount = SystemConf::getInstance()->get(emulator + ".joy_btn_count");
 	int remapCount = 0;
 	if (!sRemapCount.empty())
 		remapCount = std::stoi(sRemapCount);
@@ -4776,7 +4776,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 	for (auto it = joy_btn_recs.cbegin(); it != joy_btn_recs.cend(); it++) {
 		joy_btn_cfg->add(*it, std::to_string(i), cindex == i);
 		i++;
-	}
+	}*/
 
 	return joy_btn_cfg;
 }

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4184,7 +4184,7 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfigura
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO CREATE THE REMAP?"),
 			_("YES"), [mWindow, remap_choice, del_choice, btn_choice, remapCount, prefixName, remapName, remapNames]
 		{
-			remapCount++;
+			int count = remapCount+1;
 
 			std::string names = remapNames+","+remapName;
 			SystemConf::getInstance()->set(prefixName + ".joy_btn_names", names);
@@ -4196,7 +4196,7 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfigura
 					joyRemap += " ";
 				joyRemap += remap_choice[i]->getSelected();
 			}
-			std::string sCount = std::to_string(remapCount);
+			std::string sCount = std::to_string(count);
 			SystemConf::getInstance()->set(prefixName + ".joy_btn_order" + sCount, joyRemap);
 
 			std::string indexes = SystemConf::getInstance()->get(prefixName + ".joy_btn_indexes");
@@ -4230,7 +4230,7 @@ void GuiMenu::createBtnJoyCfgName(Window *mWindow, GuiSettings *systemConfigurat
 	auto createText = std::make_shared<TextComponent>(mWindow, _("CREATE BUTTON REMAP"), theme->Text.font, theme->Text.color);
 	row.addElement(createText, true);
 	
-	auto updateVal = [mWindow, prefixName](const std::string& newVal)
+	auto updateVal = [mWindow, prefixName, btn_choice, del_choice](const std::string& newVal)
 	{
 		if (newVal.empty()) return;
 
@@ -4317,7 +4317,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 			_("NO"), nullptr));
 	});
 	
-	systemConfiguration->addWithLabel(_("DELETE REMAP"), deleteOption);	
+	systemConfiguration->addWithLabel(_("DELETE REMAP"), del_choice);	
 	
 }
 
@@ -4420,7 +4420,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 			auto btn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
 			systemConfiguration->addWithLabel(_("BUTTON REMAP"), btn_choice);
 			systemConfiguration->addSaveFunc([mWindow, configName, btn_choice] {
-				if (joyBtn_choice->getSelectedIndex() >= 0)
+				if (btn_choice->getSelectedIndex() >= 0)
 				{
 					SystemConf::getInstance()->set(configName + ".joy_btn_cfg", btn_choice->getSelected());
 					SystemConf::getInstance()->saveSystemConf();

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4264,20 +4264,23 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 	std::string remapNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_names");
 	std::vector<std::string> arr_joy_btn_names(explode(remapNames));
 
+	std::string sIndexes = SystemConf::getInstance()->get(prefixName + ".joy_btn_indexes");
+	std::vector<int> iIndexes(int_explode(sIndexes));
+
 	del_choice->add("NONE", "-1", true);
 	int index = 0;
 	for (auto it = arr_joy_btn_names.cbegin(); it != arr_joy_btn_names.cend(); it++) {
-		del_choice->add(*it, std::to_string(index), false);
+		del_choice->add(*it, std::to_string(joy_btn_indexes[i]), false);
 		index++;
 	}
 	
-	del_choice->setSelectedChangedCallback([mWindow, del_choice, prefixName, arr_joy_btn_names, btn_choice] (std::string s) {
+	del_choice->setSelectedChangedCallback([mWindow, del_choice, prefixName, arr_joy_btn_names, btn_choice, iIndexes] (std::string s) {
 		int index = del_choice->getSelectedIndex();
 		if (index == 0)
 			return;
 		
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
-			_("YES"), [mWindow, del_choice, prefixName, arr_joy_btn_names, btn_choice]
+			_("YES"), [mWindow, del_choice, prefixName, arr_joy_btn_names, btn_choice, iIndexes]
 			{
 				std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
 				int delIndex = (del_choice->getSelectedIndex()-1);
@@ -4286,8 +4289,6 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 
 				l_arr_joy_btn_names.erase(l_arr_joy_btn_names.begin() + delIndex);
 // TODO indexes are screwing up.
-				std::string sIndexes = SystemConf::getInstance()->get(prefixName + ".joy_btn_indexes");
-				std::vector<int> iIndexes = int_explode(sIndexes);	
 				int remapIndex = iIndexes[delIndex];
 				iIndexes.erase(iIndexes.begin() + delIndex);
 
@@ -4301,7 +4302,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				SystemConf::getInstance()->set(prefixName + ".joy_btn_names", remapNames);
 				SystemConf::getInstance()->set(prefixName + ".joy_btn_order"+std::to_string(remapIndex), "");
 
-				sIndexes = "";
+				std::string sIndexes = "";
 				for(int i=0; i < iIndexes.size(); ++i)
 				{
 					if (i > 0)
@@ -5025,6 +5026,9 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 	std::string joyBtnNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_names");
 	std::vector<std::string> joy_btn_recs(explode(joyBtnNames));
 
+	std::string joyBtnIndexes = SystemConf::getInstance()->get(prefixName + ".joy_btn_indexes");
+	std::vector<int> joy_btn_indexes(int_explode(joyBtnIndexes));
+
 	int remapCount = joy_btn_recs.size();
 
 	if (prefixName == "auto" || prefixName.empty() || remapCount == 0) {
@@ -5040,7 +5044,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 	joy_btn_cfg->add("auto", "0", cfgIndex == index);
 	index++;
 	for (auto it = joy_btn_recs.cbegin(); it != joy_btn_recs.cend(); it++) {
-		joy_btn_cfg->add(*it, std::to_string(index), cfgIndex == index);
+		joy_btn_cfg->add(*it, std::to_string(joy_btn_indexes[index]), cfgIndex == joy_btn_indexes[index]);
 		index++;
 	}
 	return joy_btn_cfg;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4338,11 +4338,12 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				del_choice->remove(tName);
 
 				int btn_index = btn_choice->getSelectedIndex();
-
-				if (btn_index == old_del_choice_val || btn_index >= (btn_choice->size()-1) ||
-						btn_index == (old_del_choice_val-1))
-					btn_choice->selectFirstItem();
+				if (btn_index == old_del_choice_val)
+					btn_index = 0;
+				
+				btn_choice->selectNone();
 				btn_choice->remove(tName);
+				btn_choice->selectIndex(btn_index);
 			},
 			_("NO"), nullptr));
 	});

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4246,7 +4246,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 			return;
 		
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
-			_("YES"), [mWindow, deleteOption, prefixName, &arr_joy_btn_names]
+			_("YES"), [&, mWindow, deleteOption, prefixName, arr_joy_btn_names]
 			{
 				//std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
 				int index = atoi(deleteOption->getSelected().c_str());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4950,9 +4950,11 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 	std::string joyBtnNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_names");
 	std::vector<std::string> joy_btn_recs(explode(joyBtnNames));
 
-	int nameCount=remapCount+1;
+	//int nameCount=remapCount+1;
 
 	int cfgIndex = atoi(SystemConf::getInstance()->get(configname + ".joy_btn_cfg").c_str());
+	if (cfgIndex >= joy_btn_recs.size())
+		cfgIndex = 0;
 
 	int index = 0;
 	joy_btn_cfg->add("auto", "0", cfgIndex == index);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4372,8 +4372,11 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 				SystemConf::getInstance()->saveSystemConf();
 			}
 		});
-		GuiMenu::createBtnJoyCfgName(mWindow, systemConfiguration, tEmulator);
-		GuiMenu::deleteBtnJoyCfg(mWindow, systemConfiguration, tEmulator);
+		if (!(fileData != nullptr && fileData->getEmulator(false)))
+		{
+			GuiMenu::createBtnJoyCfgName(mWindow, systemConfiguration, tEmulator);
+			GuiMenu::deleteBtnJoyCfg(mWindow, systemConfiguration, tEmulator);
+		}
 	}
 
 #endif 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4170,7 +4170,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		systemConfiguration->addSaveFunc([configName, joyBtn_choice] {
 			if (!joyBtn_choice->getSelected().empty()) {
 				SystemConf::getInstance()->set(configName + ".joy_btn_cfg", joyBtn_choice->getSelected());
-				//SystemConf::getInstance()->saveSystemConf();
+				SystemConf::getInstance()->saveSystemConf();
 			}
 		});
 	}

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4251,6 +4251,8 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
 				int index = atoi(deleteOption->getSelected().c_str());
 
+				std::string tName = l_arr_joy_btn_names[index];
+
 				l_arr_joy_btn_names.erase(l_arr_joy_btn_names.begin() + index);
 
 				index++;
@@ -4271,6 +4273,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				
 				SystemConf::getInstance()->saveSystemConf();
 
+				deleteOption->remove(tName);
 				deleteOption->selectFirstItem();
 			}, 
 			_("NO"), nullptr));

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4184,6 +4184,8 @@ void GuiMenu::createBtnJoyCfgName(Window *mWindow, GuiSettings *mSystemConfigura
 	
 	auto updateVal = [mWindow, prefixName](const std::string& newVal)
 	{
+		if (newVal.empty()) return;
+
 		GuiSettings* systemConfiguration = new GuiSettings(mWindow, "CREATE REMAP");
 		GuiMenu::createBtnJoyCfgRemap(mWindow, systemConfiguration, prefixName, newVal);
 		mWindow->pushGui(systemConfiguration);
@@ -4191,8 +4193,6 @@ void GuiMenu::createBtnJoyCfgName(Window *mWindow, GuiSettings *mSystemConfigura
 
 	row.makeAcceptInputHandler([mWindow, createText, updateVal]
 	{
-		if (updateVal.empty()) return;
-
 		if (Settings::getInstance()->getBool("UseOSK"))
 			mWindow->pushGui(new GuiTextEditPopupKeyboard(mWindow, _("REMAP NAME"), "", updateVal, false));
 		else

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4108,7 +4108,7 @@ void GuiMenu::createBtnJoyCfg(Window *mWindow, GuiSettings *mSystemConfiguration
 			mWindow->pushGui(new GuiTextEditPopup(mWindow, _("REMAP NAME"), text->getValue(), updateVal, false));
 	});
 
-	mSystemConfiguration->addRow(row, false);
+	mSystemConfiguration->addRow(row);
 }
 #endif
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4162,7 +4162,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		});
 	}
 
-	std::string tEmulator = (currentEmulator == "auto") ? systemData->getEmulator(true) : currentEmulator);
+	std::string tEmulator = (currentEmulator == "auto") ? systemData->getEmulator(true) : currentEmulator;
 	if (systemData->isFeatureSupported(tEmulator, currentCore, EmulatorFeatures::joybtnremap))
 	{
 		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4096,7 +4096,7 @@ static std::vector<std::string> explode(std::string sData, char delimeter=',')
 	return arr;
 }
 
-static std::vector<int> explode(std::string sData, char delimeter=',')
+static std::vector<int> int_explode(std::string sData, char delimeter=',')
 {
 	std::vector<int> arr;	
 	std::stringstream ssData(sData);
@@ -4146,10 +4146,10 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfigura
 		systemConfiguration->addWithLabel(_("JOY BUTTON ")+std::to_string(index), remap_choice[index]);
 	}
 
-	systemConfiguration->addSaveFunc([mWindow, remap_choice, remapCount, prefixName, remapName] {
+	systemConfiguration->addSaveFunc([mWindow, remap_choice, del_choice, btn_choice, remapCount, prefixName, remapName] {
 		int err = 0;
 		std::string remapNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_names");
-		size_t remapCount = std::count(remapNames.begin(), remapNames.end(), ',')+1;
+		int remapCount = static_cast<int>(std::count(remapNames.begin(), remapNames.end(), ',')+1);
 		if (remapCount == 0)
 			err = 1;
 
@@ -4182,12 +4182,12 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfigura
 		}
 		
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO CREATE THE REMAP?"),
-			_("YES"), [mWindow, remap_choice, remapCount, prefixName, remapName, remapNames]
+			_("YES"), [mWindow, remap_choice, del_choice, btn_choice, remapCount, prefixName, remapName, remapNames]
 		{
 			remapCount++;
 
-			remapNames += ","+remapName;
-			SystemConf::getInstance()->set(prefixName + ".joy_btn_names", remapNames);
+			std::string names = remapNames+","+remapName;
+			SystemConf::getInstance()->set(prefixName + ".joy_btn_names", names);
 
 			std::string joyRemap = "";
 			for(int i=0; i < remapCount; ++i)
@@ -4264,7 +4264,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		index++;
 	}
 	
-	deleteOption->setSelectedChangedCallback([mWindow, del_choice, prefixName, arr_joy_btn_names, btn_choice] (std::string s) {
+	del_choice->setSelectedChangedCallback([mWindow, del_choice, prefixName, arr_joy_btn_names, btn_choice] (std::string s) {
 		int index = atoi(del_choice->getSelected().c_str());
 		if (index == -1)
 			return;
@@ -4280,7 +4280,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				l_arr_joy_btn_names.erase(l_arr_joy_btn_names.begin() + index);
 
 				std::string sIndexes = SystemConf::getInstance()->get(prefixName + ".joy_btn_indexes");
-				std::vector<int> iIndexes = explode(sIndexes);	
+				std::vector<int> iIndexes = int_explode(sIndexes);	
 				iIndexes.erase(iIndexes.begin() + index);
 
 				index++;
@@ -4309,8 +4309,8 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				del_choice->remove(tName);
 				del_choice->selectFirstItem();
 				
-				int joyBtn_index = atoi(joyBtn_choice->getSelected().c_str());
-				if (joyBtn_index == index)
+				int btn_index = atoi(btn_choice->getSelected().c_str());
+				if (btn_index == index)
 					btn_choice->selectFirstItem();
 				btn_choice->remove(tName);
 			}, 
@@ -4417,19 +4417,19 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 				return;
 			}
 
-			auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
-			systemConfiguration->addWithLabel(_("BUTTON REMAP"), joyBtn_choice);
-			systemConfiguration->addSaveFunc([mWindow, configName, joyBtn_choice] {
+			auto btn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
+			systemConfiguration->addWithLabel(_("BUTTON REMAP"), btn_choice);
+			systemConfiguration->addSaveFunc([mWindow, configName, btn_choice] {
 				if (joyBtn_choice->getSelectedIndex() >= 0)
 				{
-					SystemConf::getInstance()->set(configName + ".joy_btn_cfg", joyBtn_choice->getSelected());
+					SystemConf::getInstance()->set(configName + ".joy_btn_cfg", btn_choice->getSelected());
 					SystemConf::getInstance()->saveSystemConf();
 				}
 			});
 			if (fileData == nullptr)
 			{
-				GuiMenu::createBtnJoyCfgName(mWindow, systemConfiguration, tEmulator);
-				GuiMenu::deleteBtnJoyCfg(mWindow, systemConfiguration, joyBtn_choice, tEmulator);
+				GuiMenu::createBtnJoyCfgName(mWindow, systemConfiguration, btn_choice, del_choice, tEmulator);
+				GuiMenu::deleteBtnJoyCfg(mWindow, systemConfiguration, btn_choice, tEmulator);
 			}
 		}();
 	}

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4764,7 +4764,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 
 	int i = 0;
 	for (auto it = joy_btn_recs.cbegin(); it != joy_btn_recs.cend(); it++) {
-		joy_btn_cfg->add(*it->first, i, cindex == i);
+		joy_btn_cfg->add(*it, i, cindex == i);
 		i++;
 	}
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4280,34 +4280,35 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 {
 
 	std::string remapNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_names");
-	std::vector<std::string> arr_btn_names(explode(remapNames));
+	std::vector<std::string> remap_names(explode(remapNames));
 
 	std::string sIndexes = SystemConf::getInstance()->get(prefixName + ".joy_btn_indexes");
 	std::vector<int> iIndexes(int_explode(sIndexes));
 
 	del_choice->add("NONE", "-1", true);
 	int i = 1;
-	for (auto it = arr_btn_names.cbegin(); it != arr_btn_names.cend(); it++) {
+	for (auto it = remap_names.cbegin(); it != remap_names.cend(); it++) {
 		del_choice->add(*it, std::to_string(i), false);
 		i++;
 	}
 
-	del_choice->setSelectedChangedCallback([mWindow, btn_choice, del_choice, prefixName, arr_btn_names, iIndexes](std::string s) {
+	del_choice->setSelectedChangedCallback([mWindow, btn_choice, del_choice, prefixName, remap_names, iIndexes](std::string s) {
 		int delIndex = del_choice->getSelectedIndex();
 		if (delIndex == 0)
 			return;
 
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
-			_("YES"), [mWindow, btn_choice, del_choice, prefixName, arr_btn_names, iIndexes, delIndex]
+			_("YES"), [mWindow, btn_choice, del_choice, prefixName, remap_names, iIndexes]
 			{
-				
-				std::vector<std::string> tNames(arr_btn_names);
-				int delCfgIndex = (delIndex-1);
-				tNames.erase(tNames.begin() + delCfgIndex);
+				int delIndex = del_choice->getSelectedIndex();
 
-				std::vector<int> tIndexes(iIndexes);
-				int remapIndex = tIndexes[delIndex];
-				tIndexes.erase(tIndexes.begin() + delCfgIndex);
+				std::vector<std::string> tNames = remap_names;
+				int delCfgIndex = (delIndex-1);
+				//tNames.erase(tNames.begin() + delCfgIndex);
+
+				std::vector<int> tIndexes = iIndexes;
+				//int remapIndex = tIndexes[delIndex];
+				//tIndexes.erase(tIndexes.begin() + delCfgIndex);
 
 				std::string sRemapNames = "";
 				int i;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4237,20 +4237,21 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 	systemConfiguration->addWithLabel(_("DELETE REMAP"), deleteOption);	
 	
 	systemConfiguration->addSaveFunc([mWindow, deleteOption, prefixName, arr_joy_btn_names] {
+		std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
 		int index = atoi(deleteOption->getSelected().c_str());
 		if (index == -1)
 			return;
 
-		arr_joy_btn_names.erase(arr_joy_btn_names.begin() + index);
+		l_arr_joy_btn_names.erase(l_arr_joy_btn_names.begin() + index);
 
 		index++;
 
 		std::string remapNames = "";
-		for(int i=0; i < arr_joy_btn_names.size(); ++i)
+		for(int i=0; i < l_arr_joy_btn_names.size(); ++i)
 		{
 			if (i > 0)
 				remapNames += ",";
-			remapNames += arr_joy_btn_names[i];
+			remapNames += l_arr_joy_btn_names[i];
 		}		
 		SystemConf::getInstance()->set(prefixName + ".joy_btn_names", remapNames);
 		SystemConf::getInstance()->set(prefixName + ".joy_btn_order"+std::to_string(index), "");

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4333,17 +4333,17 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				SystemConf::getInstance()->saveSystemConf();
 
 				int old_del_choice_val = delIndex;
-				//del_choice->selectNone();
+				del_choice->selectNone();
 				//del_choice->removeIndex(delIndex);
-				//del_choice->selectFirstItem();
+				del_choice->selectFirstItem();
 
 				int btnIndex = btn_choice->getSelectedIndex();
 				if (btnIndex == old_del_choice_val || btnIndex >= del_choice->size())
 					btnIndex = 0;
 
-				//btn_choice->selectNone();
+				btn_choice->selectNone();
 				//btn_choice->removeIndex(delIndex);
-				//btn_choice->selectIndex(btnIndex);
+				btn_choice->selectIndex(btnIndex);
 			},
 			_("NO"), nullptr));
 	});

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4298,7 +4298,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 			return;
 
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
-			_("YES"), [mWindow, &btn_choice, &del_choice, prefixName, arr_btn_names, iIndexes, delIndex]
+			_("YES"), [mWindow, btn_choice, del_choice, prefixName, arr_btn_names, iIndexes, delIndex]
 			{
 				
 				std::vector<std::string> tNames(arr_btn_names);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4350,8 +4350,11 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
 		systemConfiguration->addWithLabel(_("BUTTON REMAP"), joyBtn_choice);
 		systemConfiguration->addSaveFunc([mWindow, configName, joyBtn_choice] {
+			if (!joyBtn_choice->getSelected())
+			{
 				SystemConf::getInstance()->set(configName + ".joy_btn_cfg", joyBtn_choice->getSelected());
 				SystemConf::getInstance()->saveSystemConf();
+			}
 		});
 		GuiMenu::createBtnJoyCfgName(mWindow, systemConfiguration, tEmulator);
 		GuiMenu::deleteBtnJoyCfg(mWindow, systemConfiguration, tEmulator);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4240,7 +4240,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		index++;
 	}
 	
-	deleteOption->setSelectedChangedCallback([&] (std::string s) {
+	deleteOption->setSelectedChangedCallback([&, mWindow, deleteOption, prefixName, arr_joy_btn_names] (std::string s) {
 		int index = atoi(deleteOption->getSelected().c_str());
 		if (index == -1)
 			return;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4162,7 +4162,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		});
 	}
 
-	std::string tEmulator = (currentEmulator == "auto") ? systemData->getEmulator(false) : currentEmulator;
+	std::string tEmulator = (currentEmulator == "auto") ? systemData->getEmulator(true) : currentEmulator;
 	if (systemData->isFeatureSupported(tEmulator, currentCore, EmulatorFeatures::joybtnremap))
 	{
 		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4460,7 +4460,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 					std::vector<int> btn_indexes(int_explode(btnIndexes));
 					
 					int index = btn_choice->getSelectedIndex()-1;
-					SystemConf::getInstance()->set(configName + ".joy_btn_cfg", btn_indexes[index]);
+					SystemConf::getInstance()->set(configName + ".joy_btn_cfg", std::to_string(btn_indexes[index]));
 					SystemConf::getInstance()->saveSystemConf();
 				}
 			});

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4084,25 +4084,21 @@ void GuiMenu::popGameConfigurationGui(Window* mWindow, FileData* fileData)
 // TODO 
 
 #ifdef _ENABLEEMUELEC
-void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *mSystemConfiguration, std::string prefixName)
+void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, std::string prefixName)
 {
 	
 	
 }
 
-void GuiMenu::createBtnJoyCfg(Window *mWindow, GuiSettings *mSystemConfiguration, std::string prefixName)
+void GuiMenu::createBtnJoyCfgName(Window *mWindow, std::string prefixName)
 {
-	
-	//auto text = std::make_shared<TextComponent>(mWindow, _("CREATE BUTTON REMAP"), theme->Text.font, theme->Text.color);
-	//row.addElement(text, true);
-
 	auto updateVal = [mWindow, text, prefixName, inputCfg](const std::string& newVal)
 	{
 		int remapCount = atoi(SystemConf::getInstance()->get(prefixName + ".joy_btn_count").c_str());
 		SystemConf::getInstance()->set(prefixName + ".joy_btn_count", std::to_string(++remapCount));
 		SystemConf::getInstance()->set(prefixName + ".joy_btn_name" + std::to_string(remapCount), newVal);
 
-		MenuGui::createBtnJoyCfgRemap(mWindow, SystemConf::getInstance(), prefixName);
+		MenuGui::createBtnJoyCfgRemap(mWindow, prefixName);
 	};
 
 	if (Settings::getInstance()->getBool("UseOSK"))
@@ -4203,7 +4199,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		systemConfiguration->addWithLabel(_("JOY BUTTON CFG"), joyBtn_choice);
 		systemConfiguration->addSaveFunc([configName, joyBtn_choice] {
 			if (joyBtn_choice->getSelected() == std::to_string(joyBtn_choice->size()-1)) {
-				GuiMenu::createBtnJoyCfg(mWindow, systemConfiguration, tEmulator);		
+				GuiMenu::createBtnJoyCfg(mWindow, tEmulator);		
 			}
 			else {
 				SystemConf::getInstance()->set(configName + ".joy_btn_cfg", joyBtn_choice->getSelected());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4240,7 +4240,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		index++;
 	}
 	
-	deleteOption->setSelectedChangedCallback([&] {
+	deleteOption->setSelectedChangedCallback([&] (std::string s) {
 		int index = atoi(deleteOption->getSelected().c_str());
 		if (index == -1)
 			return;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4782,8 +4782,8 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 
 	int index = 0;
 	for (auto it = joy_btn_recs.cbegin(); it != joy_btn_recs.cend(); it++) {
-		joy_btn_cfg->add(*it, std::to_string(i), cfgIndex == index);
-		i++;
+		joy_btn_cfg->add(*it, std::to_string(index), cfgIndex == index);
+		index++;
 	}
 
 	return joy_btn_cfg;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4237,22 +4237,22 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 	systemConfiguration->addWithLabel(_("DELETE REMAP"), deleteOption);	
 	
 	systemConfiguration->addSaveFunc([mWindow, deleteOption, prefixName, arr_joy_btn_names] {
-		int index = atoi(deleteOption.getSelected().c_str());
+		int index = atoi(deleteOption->getSelected().c_str());
 		if (index == -1)
 			return;
 
 		index++;
-		arr_joy_btn_names.erase(arr_joy_btn_names.begin() + index);
+		arr_joy_btn_names->erase(arr_joy_btn_names.begin() + index);
 		
-		remapNames = "";
+		std::string remapNames = "";
 		for(int i=0; i < arr_joy_btn_names.size(); ++i)
 		{
 			if (i > 0)
 				remapNames += ",";
-			remapNames += arr_joy_btn_names[i]->getSelected();
+			remapNames += arr_joy_btn_names[i];
 		}		
 		SystemConf::getInstance()->set(prefixName + ".joy_btn_names", remapNames);
-		SystemConf::getInstance()->set(prefixName + ".joy_btn_order", index);
+		SystemConf::getInstance()->set(prefixName + ".joy_btn_order"+index, "");
 		SystemConf::getInstance()->saveSystemConf();
 	});
 }

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4750,23 +4750,22 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createNativeVideoReso
 std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOptionList(Window *window, std::string configname, std::string emulator)
 {
 	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
-	int index = SystemConf::getInstance()->get(emulator + ".joy_btn_count");
+	int index = std::stoi(SystemConf::getInstance()->get(emulator + ".joy_btn_count"));
 	
 	std::vector<std::pair<std::string,std::string>> joy_btn_recs;
 	for (int i=0; i < index; ++i) {
-		std::string name = SystemConf::getInstance()->get(emulator + ".joy_btn_name"+i);
-		std::string val = SystemConf::getInstance()->get(emulator + ".joy_btn_order"+i);
-		std::pair<std::string,std:string> rec{name,val};
+		std::string name = SystemConf::getInstance()->get(emulator + ".joy_btn_name" + std::tostring(i));
+		std::string val = SystemConf::getInstance()->get(emulator + ".joy_btn_order" + std::tostring(i));
+		std::pair<std::string,std::string> rec{name,val};
 		joy_btn_recs.push_back(rec);
 	}
 	
-	std::string index = SystemConf::getInstance()->get(configname + ".joy_btn_cfg");
-	if (index.empty())
-		index = "auto";
+	std::string sIndex = SystemConf::getInstance()->get(configname + ".joy_btn_cfg");
+	if (sIndex.empty())
+		sIndex = "auto";
 
-// TODO
 	for (auto it = joy_btn_recs.cbegin(); it != joy_btn_recs.cend(); it++) {
-		joy_btn_cfg->add(it->first, it->second, index == it->second);
+		joy_btn_cfg->add(it->first, it->second, sIndex == it->first);
 	}
 
 	return joy_btn_cfg;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4168,7 +4168,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		systemConfiguration->addSaveFunc([configName, joyBtn_choice] {
 			if (!joyBtn_choice->getSelected().empty()) {
 				SystemConf::getInstance()->set(configName + ".joy_btn_cfg", joyBtn_choice->getSelected());
-				SystemConf::getInstance()->saveSystemConf();
+				//SystemConf::getInstance()->saveSystemConf();
 			}
 		});
 	}

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4372,7 +4372,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 				SystemConf::getInstance()->saveSystemConf();
 			}
 		});
-		if (!(fileData != nullptr && fileData->getEmulator(false)))
+		if (fileData == nullptr)
 		{
 			GuiMenu::createBtnJoyCfgName(mWindow, systemConfiguration, tEmulator);
 			GuiMenu::deleteBtnJoyCfg(mWindow, systemConfiguration, tEmulator);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4240,27 +4240,27 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		index++;
 	}
 	
-	deleteOption->setSelectedChangedCallback([&, mWindow, deleteOption, prefixName, arr_joy_btn_names] (std::string s) {
+	deleteOption->setSelectedChangedCallback([mWindow, deleteOption, prefixName, &arr_joy_btn_names] (std::string s) {
 		int index = atoi(deleteOption->getSelected().c_str());
 		if (index == -1)
 			return;
 		
 		mWindow->pushGui(new GuiMsgBox(mWindow, _("ARE YOU SURE YOU WANT TO DELETE THE REMAP?"),
-			_("YES"), [mWindow, deleteOption, prefixName, arr_joy_btn_names]
+			_("YES"), [mWindow, deleteOption, prefixName, &arr_joy_btn_names]
 			{
-				std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
+				//std::vector<std::string> l_arr_joy_btn_names(arr_joy_btn_names);
 				int index = atoi(deleteOption->getSelected().c_str());
 
-				l_arr_joy_btn_names.erase(l_arr_joy_btn_names.begin() + index);
+				arr_joy_btn_names.erase(arr_joy_btn_names.begin() + index);
 
 				index++;
 
 				std::string remapNames = "";
-				for(int i=0; i < l_arr_joy_btn_names.size(); ++i)
+				for(int i=0; i < arr_joy_btn_names.size(); ++i)
 				{
 					if (i > 0)
 						remapNames += ",";
-					remapNames += l_arr_joy_btn_names[i];
+					remapNames += arr_joy_btn_names[i];
 				}		
 				SystemConf::getInstance()->set(prefixName + ".joy_btn_names", remapNames);
 				SystemConf::getInstance()->set(prefixName + ".joy_btn_order"+std::to_string(index), "");
@@ -4269,7 +4269,9 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				if (count > 0)
 					SystemConf::getInstance()->set(prefixName + ".joy_btn_map_count", std::to_string(--count));
 				
-				SystemConf::getInstance()->saveSystemConf();			
+				SystemConf::getInstance()->saveSystemConf();
+
+				deleteOption->selectFirstItem();
 			}, 
 			_("NO"), nullptr));
 	});

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -5054,8 +5054,8 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnCfgOption
 	std::vector<std::string> btn_names(explode(btnNames));
 
 	if (prefixName == "auto" || prefixName.empty() || btn_names.size() == 0) {
-		joy_btn_cfg->add("auto", "0", true);
-		return joy_btn_cfg;
+		btn_cfg->add("auto", "0", true);
+		return btn_cfg;
 	}
 
 	int cfgIndex = atoi(SystemConf::getInstance()->get(configname + ".joy_btn_cfg").c_str());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4094,17 +4094,9 @@ void GuiMenu::createJoyBtnCfgOptionList(Window *mWindow, std::string title)
 
 	ComponentListRow row;
 	
-	mTextRemap = std::make_shared<TextComponent>(mWindow, _("CREATE BUTTON REMAP"), font, color);
+	auto mTextRemap = std::make_shared<TextComponent>(mWindow, _("CREATE BUTTON REMAP"), font, color);
 	row.addElement(mTextRemap, true);
 
-	auto spacer = std::make_shared<GuiComponent>(mWindow);
-	spacer->setSize(Renderer::getScreenWidth() * 0.005f, 0);
-	row.addElement(spacer, false);
-
-	auto bracket = std::make_shared<ImageComponent>(mWindow);
-
-	bracket->setResize(Vector2f(0, lbl->getFont()->getLetterHeight()));
-	row.addElement(bracket, false);
 
 	auto updateVal = [this](const std::string& newVal)
 	{
@@ -4113,7 +4105,7 @@ void GuiMenu::createJoyBtnCfgOptionList(Window *mWindow, std::string title)
 		// save to config
 	};
 
-	row.makeAcceptInputHandler([this, updateVal]
+	row.makeAcceptInputHandler([mTextRemap, updateVal]
 	{
 		if (Settings::getInstance()->getBool("UseOSK"))
 			mWindow->pushGui(new GuiTextEditPopupKeyboard(mWindow, _("CREATE BUTTON REMAP NAME"), mTextRemap->getValue(), updateVal, false));

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4165,7 +4165,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::joybtnremap) ||
 			systemData->isFeatureSupported(systemData->getEmulator(), systemData->getCore(), EmulatorFeatures::joybtnremap))
 	{
-		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, currentCore);
+		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, systemData->getEmulator());
 		systemConfiguration->addWithLabel(_("JOY BUTTON CFG"), joyBtn_choice);
 		systemConfiguration->addSaveFunc([configName, joyBtn_choice] {
 			if (!joyBtn_choice->getSelected().empty()) {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4251,9 +4251,11 @@ void GuiMenu::createBtnJoyCfgName(Window *mWindow, GuiSettings *systemConfigurat
 }
 
 void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
-	 std::shared_ptr<OptionListComponent<std::string>> btn_choice, std::string prefixName) {
-	auto del_choice = std::make_shared<OptionListComponent<std::string>>(mWindow, _("DELETE REMAP"), false);
-	
+	 std::shared_ptr<OptionListComponent<std::string>> btn_choice,
+	 std::shared_ptr<OptionListComponent<std::string>> del_choice,
+	 std::string prefixName)
+{
+
 	std::string remapNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_names");
 	std::vector<std::string> arr_joy_btn_names(explode(remapNames));
 
@@ -4418,6 +4420,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 			}
 
 			auto btn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
+			auto del_choice = std::make_shared<OptionListComponent<std::string>>(mWindow, _("DELETE REMAP"), false);
 			systemConfiguration->addWithLabel(_("BUTTON REMAP"), btn_choice);
 			systemConfiguration->addSaveFunc([mWindow, configName, btn_choice] {
 				if (btn_choice->getSelectedIndex() >= 0)
@@ -4429,7 +4432,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 			if (fileData == nullptr)
 			{
 				GuiMenu::createBtnJoyCfgName(mWindow, systemConfiguration, btn_choice, del_choice, tEmulator);
-				GuiMenu::deleteBtnJoyCfg(mWindow, systemConfiguration, btn_choice, tEmulator);
+				GuiMenu::deleteBtnJoyCfg(mWindow, systemConfiguration, btn_choice, del_choice, tEmulator);
 			}
 		}();
 	}

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4338,7 +4338,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				del_choice->remove(tName);
 
 				int btn_index = btn_choice->getSelectedIndex();
-				if (btn_index == old_del_choice_val)
+				if (btn_index == old_del_choice_val || btn_index >= del_choice->size())
 					btn_index = 0;
 				
 				btn_choice->selectNone();

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4254,6 +4254,7 @@ void GuiMenu::createBtnJoyCfgName(Window *mWindow, GuiSettings *systemConfigurat
 	systemConfiguration->addRow(row);
 }
 
+// TODO - Sometimes crashes ES when removing from middle.
 void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 	 std::shared_ptr<OptionListComponent<std::string>> btn_choice,
 	 std::shared_ptr<OptionListComponent<std::string>> del_choice,
@@ -4310,10 +4311,10 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 				SystemConf::getInstance()->set(prefixName + ".joy_btn_indexes", sIndexes);
 
 				SystemConf::getInstance()->saveSystemConf();
-
-				del_choice->remove(tName);
-				del_choice->selectFirstItem();
 				
+				del_choice->selectFirstItem();
+				del_choice->remove(tName);
+
 				int btn_index = atoi(btn_choice->getSelected().c_str());
 				if (btn_index >= btn_choice->size())
 					btn_choice->selectFirstItem();

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4085,7 +4085,7 @@ void GuiMenu::popGameConfigurationGui(Window* mWindow, FileData* fileData)
 
 #ifdef _ENABLEEMUELEC
 
-std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnRemapOptionList(Window *window, std::string configname, std::string prefixName, int btnIndex)
+std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnRemapOptionList(Window *window, std::string prefixName, int btnIndex)
 {
 	auto joy_btn_cfg = std::make_shared< OptionListComponent<std::string> >(window, "JOY BUTTON CFG", false);
 
@@ -4124,17 +4124,17 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *mSystemConfigur
 	for (int index=0; index < remapCount; ++index)
 	{
 		
-		remap_choice.push_back(createJoyBtnRemapOptionList(mWindow, configName, tEmulator, index));
-		mSystemConfiguration->addWithLabel(_("JOY BUTTON "+std::to_string(index)), remap_choice[index]);
+		remap_choice.push_back(createJoyBtnRemapOptionList(mWindow, prefixName, index));
+		mSystemConfiguration->addWithLabel(_("JOY BUTTON ")+std::to_string(index), remap_choice[index]);
 		mSystemConfiguration->addSaveFunc([mWindow, configName, remap_choice, remapCount, prefixName, remapName, index] {
 
 			for(int i=0; i < remapCount; ++i)
 			{
-				int choice = atoi(remap_choice[i]->getSelected()).c_str();
+				int choice = atoi(remap_choice[i]->getSelected().c_str());
 				if (choice == -1)
 					return;
 				for(int j=0; j < remapCount; ++j) {
-					int choice2 = atoi(remap_choice[j]->getSelected()).c_str();
+					int choice2 = atoi(remap_choice[j]->getSelected().c_str());
 					if (choice == -1)
 						return;
 					if (i != j && choice == choice2) {
@@ -4153,7 +4153,7 @@ void GuiMenu::createBtnJoyCfgRemap(Window *mWindow, GuiSettings *mSystemConfigur
 			{
 				if (i > 0)
 					joyRemap += " ";
-				joyRemap += remap_choice[i].getSelected();
+				joyRemap += remap_choice[i]->getSelected();
 			}
 			SystemConf::getInstance()->set(prefixName + ".joy_btn_order" + std::to_string(remapCount), joyRemap);
 		});	

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4339,7 +4339,8 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 
 				int btn_index = btn_choice->getSelectedIndex();
 
-				if (btn_index == old_del_choice_val || btn_index >= (btn_choice->size()-1))
+				if (btn_index == old_del_choice_val || btn_index >= (btn_choice->size()-1) ||
+						btn_index == (old_del_choice_val-1))
 					btn_choice->selectFirstItem();
 				btn_choice->remove(tName);
 			},

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4162,10 +4162,11 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		});
 	}
 
+	std::string tEmulator = (systemData->getEmulator().empty() ? currentEmulator : systemData->getEmulator())
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::joybtnremap) ||
-			systemData->isFeatureSupported(systemData->getEmulator(), systemData->getCore(), EmulatorFeatures::joybtnremap))
+			systemData->isFeatureSupported(tEmulator, currentCore, EmulatorFeatures::joybtnremap))
 	{
-		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, systemData->getEmulator());
+		auto joyBtn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
 		systemConfiguration->addWithLabel(_("JOY BUTTON CFG"), joyBtn_choice);
 		systemConfiguration->addSaveFunc([configName, joyBtn_choice] {
 			if (!joyBtn_choice->getSelected().empty() || joyBtn_choice->getSelected() != "0") {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4452,13 +4452,14 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 			auto btn_choice = createJoyBtnCfgOptionList(mWindow, configName, tEmulator);
 			auto del_choice = std::make_shared<OptionListComponent<std::string>>(mWindow, _("DELETE REMAP"), false);
 			systemConfiguration->addWithLabel(_("BUTTON REMAP"), btn_choice);
-			systemConfiguration->addSaveFunc([configName, btn_choice] {
+			std::string prefixName = tEmulator;
+			systemConfiguration->addSaveFunc([configName, btn_choice, prefixName] {
 				if (btn_choice->getSelectedIndex() >= 0)
 				{
 					std::string btnIndexes = SystemConf::getInstance()->get(prefixName + ".joy_btn_indexes");
 					std::vector<int> btn_indexes(int_explode(btnIndexes));
 					
-					int index = atoi(btn_choice->getSelected().c_str())-1;
+					int index = btn_choice->getSelectedIndex()-1;
 					SystemConf::getInstance()->set(configName + ".joy_btn_cfg", btn_indexes[index]);
 					SystemConf::getInstance()->saveSystemConf();
 				}

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4241,9 +4241,10 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 		if (index == -1)
 			return;
 
+		arr_joy_btn_names.erase(arr_joy_btn_names.begin() + index);
+
 		index++;
-		arr_joy_btn_names->erase(arr_joy_btn_names.begin() + index);
-		
+
 		std::string remapNames = "";
 		for(int i=0; i < arr_joy_btn_names.size(); ++i)
 		{
@@ -4252,7 +4253,7 @@ void GuiMenu::deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
 			remapNames += arr_joy_btn_names[i];
 		}		
 		SystemConf::getInstance()->set(prefixName + ".joy_btn_names", remapNames);
-		SystemConf::getInstance()->set(prefixName + ".joy_btn_order"+index, "");
+		SystemConf::getInstance()->set(prefixName + ".joy_btn_order"+std::to_string(index), "");
 		SystemConf::getInstance()->saveSystemConf();
 	});
 }

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -97,7 +97,7 @@ private:
 #ifdef _ENABLEEMUELEC
   static std::shared_ptr<OptionListComponent<std::string>> createNativeVideoResolutionModeOptionList(Window *window, std::string configname);
   static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnCfgOptionList(Window *window, std::string configname, std::string prefixName);
-  static void createBtnJoyCfg(Window *mWindow, std::string title);
+  static void createBtnJoyCfg(Window *mWindow, GuiSettings *mSystemConfiguration, std::string title);
 #endif
 	static std::shared_ptr<OptionListComponent<std::string>> createVideoResolutionModeOptionList(Window *window, std::string configname);
 	static void popSpecificConfigurationGui(Window* mWindow, std::string title, std::string configName, SystemData *systemData, FileData* fileData, bool selectCoreLine = false);

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -101,7 +101,7 @@ private:
   static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnRemapOptionList(Window *window, std::string prefixName, int btnIndex);
   static void createBtnJoyCfgName(Window *mWindow, GuiSettings *systemConfiguration, std::string prefixName);
   static void createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfiguration, std::string prefixName, std::string remapName);
-  static void deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration, std::string prefixName);
+  static void deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration, std::shared_ptr<OptionListComponent<std::string>> joyBtn_choice, std::string prefixName);
 #endif
 	static std::shared_ptr<OptionListComponent<std::string>> createVideoResolutionModeOptionList(Window *window, std::string configname);
 	static void popSpecificConfigurationGui(Window* mWindow, std::string title, std::string configName, SystemData *systemData, FileData* fileData, bool selectCoreLine = false);

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -96,6 +96,7 @@ private:
 	static std::shared_ptr<OptionListComponent<std::string>> createRatioOptionList(Window *window, std::string configname);
 #ifdef _ENABLEEMUELEC
   static std::shared_ptr<OptionListComponent<std::string>> createNativeVideoResolutionModeOptionList(Window *window, std::string configname);
+  static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnCfgOptionList(Window *window, std::string configname, std::string emulator);
 #endif
 	static std::shared_ptr<OptionListComponent<std::string>> createVideoResolutionModeOptionList(Window *window, std::string configname);
 	static void popSpecificConfigurationGui(Window* mWindow, std::string title, std::string configName, SystemData *systemData, FileData* fileData, bool selectCoreLine = false);

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -96,7 +96,7 @@ private:
 	static std::shared_ptr<OptionListComponent<std::string>> createRatioOptionList(Window *window, std::string configname);
 #ifdef _ENABLEEMUELEC
   static std::shared_ptr<OptionListComponent<std::string>> createNativeVideoResolutionModeOptionList(Window *window, std::string configname);
-  static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnCfgOptionList(Window *window, std::string configname, std::string emulator);
+  static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnCfgOptionList(Window *window, std::string configname, std::string core);
 #endif
 	static std::shared_ptr<OptionListComponent<std::string>> createVideoResolutionModeOptionList(Window *window, std::string configname);
 	static void popSpecificConfigurationGui(Window* mWindow, std::string title, std::string configName, SystemData *systemData, FileData* fileData, bool selectCoreLine = false);

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -97,7 +97,7 @@ private:
 #ifdef _ENABLEEMUELEC
   static std::shared_ptr<OptionListComponent<std::string>> createNativeVideoResolutionModeOptionList(Window *window, std::string configname);
   static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnCfgOptionList(Window *window, std::string configname, std::string prefixName);
-  static void createBtnJoyCfg(Window *mWindow, GuiSettings *mSystemConfiguration, std::string title);
+  static void createBtnJoyCfg(Window *mWindow, GuiSettings *mSystemConfiguration, std::string prefixName);
 #endif
 	static std::shared_ptr<OptionListComponent<std::string>> createVideoResolutionModeOptionList(Window *window, std::string configname);
 	static void popSpecificConfigurationGui(Window* mWindow, std::string title, std::string configName, SystemData *systemData, FileData* fileData, bool selectCoreLine = false);

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -97,7 +97,8 @@ private:
 #ifdef _ENABLEEMUELEC
   static std::shared_ptr<OptionListComponent<std::string>> createNativeVideoResolutionModeOptionList(Window *window, std::string configname);
   static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnCfgOptionList(Window *window, std::string configname, std::string prefixName);
-  static void createBtnJoyCfg(Window *mWindow, GuiSettings *mSystemConfiguration, std::string prefixName);
+  static void createBtnJoyCfgName(Window *mWindow, std::string prefixName);
+  static void createBtnJoyCfgRemap(Window *mWindow, std::string prefixName);
 #endif
 	static std::shared_ptr<OptionListComponent<std::string>> createVideoResolutionModeOptionList(Window *window, std::string configname);
 	static void popSpecificConfigurationGui(Window* mWindow, std::string title, std::string configName, SystemData *systemData, FileData* fileData, bool selectCoreLine = false);

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -98,9 +98,9 @@ private:
   static std::shared_ptr<OptionListComponent<std::string>> createNativeVideoResolutionModeOptionList(Window *window, std::string configname);
   static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnCfgOptionList(Window *window, std::string configname, std::string prefixName);
   
-  static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnRemapOptionList(Window *window, std::string configname, std::string prefixName, int btnIndex)
+  static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnRemapOptionList(Window *window, std::string configname, std::string prefixName, int btnIndex);
   static void createBtnJoyCfgName(Window *mWindow, GuiSettings *mSystemConfiguration, std::string prefixName);
-  static void createBtnJoyCfgRemap(Window *mWindow, GuiSettings *mSystemConfiguration, std::string prefixName);
+  static void createBtnJoyCfgRemap(Window *mWindow, GuiSettings *mSystemConfiguration, std::string prefixName, std::string remapName);
   
 #endif
 	static std::shared_ptr<OptionListComponent<std::string>> createVideoResolutionModeOptionList(Window *window, std::string configname);

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -99,9 +99,14 @@ private:
   static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnCfgOptionList(Window *window, std::string configname, std::string prefixName);
   
   static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnRemapOptionList(Window *window, std::string prefixName, int btnIndex);
-  static void createBtnJoyCfgName(Window *mWindow, GuiSettings *systemConfiguration, std::string prefixName);
-  static void createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfiguration, std::string prefixName, std::string remapName);
-  static void deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration, std::shared_ptr<OptionListComponent<std::string>> joyBtn_choice, std::string prefixName);
+  static void createBtnJoyCfgName(Window *mWindow, GuiSettings *systemConfiguration,
+    std::shared_ptr<OptionListComponent<std::string>> btn_choice, std::shared_ptr<OptionListComponent<std::string>> del_choice,
+    std::string prefixName);
+  static void createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfiguration,
+    std::shared_ptr<OptionListComponent<std::string>> btn_choice, std::shared_ptr<OptionListComponent<std::string>> del_choice,
+    std::string prefixName, std::string remapName);
+  static void deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
+    std::shared_ptr<OptionListComponent<std::string>> btn_choice, std::string prefixName);
 #endif
 	static std::shared_ptr<OptionListComponent<std::string>> createVideoResolutionModeOptionList(Window *window, std::string configname);
 	static void popSpecificConfigurationGui(Window* mWindow, std::string title, std::string configName, SystemData *systemData, FileData* fileData, bool selectCoreLine = false);

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -106,7 +106,8 @@ private:
     std::shared_ptr<OptionListComponent<std::string>> btn_choice, std::shared_ptr<OptionListComponent<std::string>> del_choice,
     std::string prefixName, std::string remapName);
   static void deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration,
-    std::shared_ptr<OptionListComponent<std::string>> btn_choice, std::string prefixName);
+    std::shared_ptr<OptionListComponent<std::string>> btn_choice, std::shared_ptr<OptionListComponent<std::string>> del_choice,
+    std::string prefixName);
 #endif
 	static std::shared_ptr<OptionListComponent<std::string>> createVideoResolutionModeOptionList(Window *window, std::string configname);
 	static void popSpecificConfigurationGui(Window* mWindow, std::string title, std::string configName, SystemData *systemData, FileData* fileData, bool selectCoreLine = false);

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -98,7 +98,7 @@ private:
   static std::shared_ptr<OptionListComponent<std::string>> createNativeVideoResolutionModeOptionList(Window *window, std::string configname);
   static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnCfgOptionList(Window *window, std::string configname, std::string prefixName);
   
-  static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnRemapOptionList(Window *window, std::string configname, std::string prefixName, int btnIndex);
+  static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnRemapOptionList(Window *window, std::string prefixName, int btnIndex);
   static void createBtnJoyCfgName(Window *mWindow, GuiSettings *mSystemConfiguration, std::string prefixName);
   static void createBtnJoyCfgRemap(Window *mWindow, GuiSettings *mSystemConfiguration, std::string prefixName, std::string remapName);
   

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -96,7 +96,7 @@ private:
 	static std::shared_ptr<OptionListComponent<std::string>> createRatioOptionList(Window *window, std::string configname);
 #ifdef _ENABLEEMUELEC
   static std::shared_ptr<OptionListComponent<std::string>> createNativeVideoResolutionModeOptionList(Window *window, std::string configname);
-  static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnCfgOptionList(Window *window, std::string configname, std::string systemName);
+  static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnCfgOptionList(Window *window, std::string configname, std::string prefixName);
 #endif
 	static std::shared_ptr<OptionListComponent<std::string>> createVideoResolutionModeOptionList(Window *window, std::string configname);
 	static void popSpecificConfigurationGui(Window* mWindow, std::string title, std::string configName, SystemData *systemData, FileData* fileData, bool selectCoreLine = false);

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -97,7 +97,7 @@ private:
 #ifdef _ENABLEEMUELEC
   static std::shared_ptr<OptionListComponent<std::string>> createNativeVideoResolutionModeOptionList(Window *window, std::string configname);
   static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnCfgOptionList(Window *window, std::string configname, std::string prefixName);
-  static void createJoyBtnCfgOptionList(Window *mWindow, std::string title);
+  static void createBtnJoyCfg(Window *mWindow, std::string title);
 #endif
 	static std::shared_ptr<OptionListComponent<std::string>> createVideoResolutionModeOptionList(Window *window, std::string configname);
 	static void popSpecificConfigurationGui(Window* mWindow, std::string title, std::string configName, SystemData *systemData, FileData* fileData, bool selectCoreLine = false);

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -97,6 +97,7 @@ private:
 #ifdef _ENABLEEMUELEC
   static std::shared_ptr<OptionListComponent<std::string>> createNativeVideoResolutionModeOptionList(Window *window, std::string configname);
   static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnCfgOptionList(Window *window, std::string configname, std::string prefixName);
+  static void createJoyBtnCfgOptionList(Window *mWindow, std::string title);
 #endif
 	static std::shared_ptr<OptionListComponent<std::string>> createVideoResolutionModeOptionList(Window *window, std::string configname);
 	static void popSpecificConfigurationGui(Window* mWindow, std::string title, std::string configName, SystemData *systemData, FileData* fileData, bool selectCoreLine = false);

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -96,7 +96,7 @@ private:
 	static std::shared_ptr<OptionListComponent<std::string>> createRatioOptionList(Window *window, std::string configname);
 #ifdef _ENABLEEMUELEC
   static std::shared_ptr<OptionListComponent<std::string>> createNativeVideoResolutionModeOptionList(Window *window, std::string configname);
-  static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnCfgOptionList(Window *window, std::string configname, std::string core);
+  static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnCfgOptionList(Window *window, std::string configname, std::string systemName);
 #endif
 	static std::shared_ptr<OptionListComponent<std::string>> createVideoResolutionModeOptionList(Window *window, std::string configname);
 	static void popSpecificConfigurationGui(Window* mWindow, std::string title, std::string configName, SystemData *systemData, FileData* fileData, bool selectCoreLine = false);

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -99,9 +99,9 @@ private:
   static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnCfgOptionList(Window *window, std::string configname, std::string prefixName);
   
   static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnRemapOptionList(Window *window, std::string prefixName, int btnIndex);
-  static void createBtnJoyCfgName(Window *mWindow, GuiSettings *mSystemConfiguration, std::string prefixName);
+  static void createBtnJoyCfgName(Window *mWindow, GuiSettings *systemConfiguration, std::string prefixName);
   static void createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfiguration, std::string prefixName, std::string remapName);
-  
+  static void deleteBtnJoyCfg(Window *mWindow, GuiSettings *systemConfiguration, std::string prefixName);
 #endif
 	static std::shared_ptr<OptionListComponent<std::string>> createVideoResolutionModeOptionList(Window *window, std::string configname);
 	static void popSpecificConfigurationGui(Window* mWindow, std::string title, std::string configName, SystemData *systemData, FileData* fileData, bool selectCoreLine = false);

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -100,7 +100,7 @@ private:
   
   static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnRemapOptionList(Window *window, std::string prefixName, int btnIndex);
   static void createBtnJoyCfgName(Window *mWindow, GuiSettings *mSystemConfiguration, std::string prefixName);
-  static void createBtnJoyCfgRemap(Window *mWindow, GuiSettings *mSystemConfiguration, std::string prefixName, std::string remapName);
+  static void createBtnJoyCfgRemap(Window *mWindow, GuiSettings *systemConfiguration, std::string prefixName, std::string remapName);
   
 #endif
 	static std::shared_ptr<OptionListComponent<std::string>> createVideoResolutionModeOptionList(Window *window, std::string configname);

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -97,8 +97,11 @@ private:
 #ifdef _ENABLEEMUELEC
   static std::shared_ptr<OptionListComponent<std::string>> createNativeVideoResolutionModeOptionList(Window *window, std::string configname);
   static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnCfgOptionList(Window *window, std::string configname, std::string prefixName);
-  static void createBtnJoyCfgName(Window *mWindow, std::string prefixName);
-  static void createBtnJoyCfgRemap(Window *mWindow, std::string prefixName);
+  
+  static std::shared_ptr<OptionListComponent<std::string>> createJoyBtnRemapOptionList(Window *window, std::string configname, std::string prefixName, int btnIndex)
+  static void createBtnJoyCfgName(Window *mWindow, GuiSettings *mSystemConfiguration, std::string prefixName);
+  static void createBtnJoyCfgRemap(Window *mWindow, GuiSettings *mSystemConfiguration, std::string prefixName);
+  
 #endif
 	static std::shared_ptr<OptionListComponent<std::string>> createVideoResolutionModeOptionList(Window *window, std::string configname);
 	static void popSpecificConfigurationGui(Window* mWindow, std::string title, std::string configName, SystemData *systemData, FileData* fileData, bool selectCoreLine = false);

--- a/es-core/src/components/OptionListComponent.h
+++ b/es-core/src/components/OptionListComponent.h
@@ -526,6 +526,14 @@ public:
 	}
 
 #ifdef _ENABLEEMUELEC
+	void removeIndex(const int index)
+	{
+		if (mEntries.at(index).selected)
+			mEntries.at(0).selected = true;
+		mEntries.at(index).selected = false;
+		mEntries.erase(mEntries.cbegin()+index);
+	}
+
 	void selectIndex(unsigned int i)
 	{
 		selectNone();

--- a/es-core/src/components/OptionListComponent.h
+++ b/es-core/src/components/OptionListComponent.h
@@ -528,10 +528,10 @@ public:
 #ifdef _ENABLEEMUELEC
 	void removeIndex(const int index)
 	{
-		if (mEntries.at(index).selected)
-			mEntries.at(0).selected = true;
-		mEntries.at(index).selected = false;
-		mEntries.erase(mEntries.cbegin()+index);
+		if (index <= 0 || index >= mEntries.size())
+			return;
+
+		mEntries.erase(mEntries.begin()+index);
 	}
 
 	void selectIndex(unsigned int i)

--- a/es-core/src/components/OptionListComponent.h
+++ b/es-core/src/components/OptionListComponent.h
@@ -526,12 +526,12 @@ public:
 	}
 
 #ifdef _ENABLEEMUELEC
-	void removeIndex(const int index)
+	void removeIndex(const int i)
 	{
-		if (index <= 0 || index >= mEntries.size())
+		if (i <= 0 || i >= mEntries.size())
 			return;
 
-		mEntries.erase(mEntries.begin()+index);
+		mEntries.erase(mEntries.at(i));
 	}
 
 	void selectIndex(unsigned int i)

--- a/es-core/src/components/OptionListComponent.h
+++ b/es-core/src/components/OptionListComponent.h
@@ -525,6 +525,15 @@ public:
 		onSelectedChanged();
 	}
 
+#ifdef _ENABLEEMUELEC
+	void selectIndex(unsigned int i)
+	{
+		selectNone();
+		mEntries.at(i).selected = true;
+		onSelectedChanged();
+	}
+#endif
+
 	void clear() {
 		mEntries.clear();
 	}

--- a/es-core/src/components/OptionListComponent.h
+++ b/es-core/src/components/OptionListComponent.h
@@ -531,7 +531,8 @@ public:
 		if (i <= 0 || i >= mEntries.size())
 			return;
 
-		mEntries.erase(mEntries.at(i));
+		auto sysIt = mEntries.cbegin() + i;
+		mEntries.erase(sysIt;
 	}
 
 	void selectIndex(unsigned int i)

--- a/es-core/src/components/OptionListComponent.h
+++ b/es-core/src/components/OptionListComponent.h
@@ -532,7 +532,7 @@ public:
 			return;
 
 		auto sysIt = mEntries.cbegin() + i;
-		mEntries.erase(sysIt;
+		mEntries.erase(sysIt);
 	}
 
 	void selectIndex(unsigned int i)


### PR DESCRIPTION
The changes for doing remaps to Advmame, adding in ES and also removing. To make it work you need the following values in emuelec.conf. By default there should be the default mapping, and a mk and sf for the fighting games. You should be able to add mappings via ES, and remove them accordingly.

```
# Enable Advance mame config buttom remapping 1,0 (default 0 disabled)
advmame_joy_remap=1

AdvanceMame.joy_btns=input a button,input b button,input x button,input y button,input r button,input l button,input r2 button,input l2 button

AdvanceMame.joy_btn_indexes=1,2
AdvanceMame.joy_btn_names=mk,sf

AdvanceMame.joy_btn_order0=0 1 2 3 4 5 6 7
AdvanceMame.joy_btn_order1=3 4 2 1 0 5 6 7
AdvanceMame.joy_btn_order2=3 2 5 1 0 4 6 7
```