### PR TITLE
Ee handheld argument for resolution safeguarding.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ endif()
 
 if("${ENABLE_GAMEFORCE}" STREQUAL "1")
   add_definitions(-D_ENABLEGAMEFORCE)
+  add_definitions(-D_ENABLEHANDHELD)
 endif()
 
 if("${ENABLE_HANDHELD}" STREQUAL "1")
@@ -45,6 +46,7 @@ endif()
 
 if("${ODROIDGOA}" STREQUAL "1")
   add_definitions(-DODROIDGOA)
+  add_definitions(-D_ENABLEHANDHELD)
 endif()
 
 if(BATOCERA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(ENABLE_TTS "Set to ON to enable text to speech" OFF)
 option(ENABLE_EMUELEC "Set to ON to enable EmuELEC changes" ${ENABLE_EMUELEC})
 option(ENABLE_GAMEFORCE "Set to ON to enable Gameforce specific changes" ${ENABLE_GAMEFORCE})
 option(ODROIDGOA "Set to ON to enable Odroid Go Advance specific changes" ${ODROIDGOA})
+option(ENABLE_ROCKCHIP "Set to ON to enable Rockchip specific changes" ${ENABLE_ROCKCHIP})
 
 project(emulationstation-all)
 
@@ -36,6 +37,10 @@ endif()
 
 if("${ENABLE_GAMEFORCE}" STREQUAL "1")
   add_definitions(-D_ENABLEGAMEFORCE)
+endif()
+
+if("${ENABLE_ROCKCHIP}" STREQUAL "1")
+  add_definitions(-D_ENABLEROCKCHIP)
 endif()
 
 if("${ODROIDGOA}" STREQUAL "1")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ option(ENABLE_TTS "Set to ON to enable text to speech" OFF)
 option(ENABLE_EMUELEC "Set to ON to enable EmuELEC changes" ${ENABLE_EMUELEC})
 option(ENABLE_GAMEFORCE "Set to ON to enable Gameforce specific changes" ${ENABLE_GAMEFORCE})
 option(ODROIDGOA "Set to ON to enable Odroid Go Advance specific changes" ${ODROIDGOA})
-option(ENABLE_ROCKCHIP "Set to ON to enable Rockchip specific changes" ${ENABLE_ROCKCHIP})
+option(ENABLE_HANDHELD "Set to ON to enable Handheld specific changes" ${ENABLE_HANDHELD})
 
 project(emulationstation-all)
 
@@ -39,8 +39,8 @@ if("${ENABLE_GAMEFORCE}" STREQUAL "1")
   add_definitions(-D_ENABLEGAMEFORCE)
 endif()
 
-if("${ENABLE_ROCKCHIP}" STREQUAL "1")
-  add_definitions(-D_ENABLEROCKCHIP)
+if("${ENABLE_HANDHELD}" STREQUAL "1")
+  add_definitions(-D_ENABLEHANDHELD)
 endif()
 
 if("${ODROIDGOA}" STREQUAL "1")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,12 +40,12 @@ if("${ENABLE_GAMEFORCE}" STREQUAL "1")
   add_definitions(-D_ENABLEHANDHELD)
 endif()
 
-if("${ENABLE_HANDHELD}" STREQUAL "1")
+if("${ODROIDGOA}" STREQUAL "1")
+  add_definitions(-DODROIDGOA)
   add_definitions(-D_ENABLEHANDHELD)
 endif()
 
-if("${ODROIDGOA}" STREQUAL "1")
-  add_definitions(-DODROIDGOA)
+if("${ENABLE_HANDHELD}" STREQUAL "1")
   add_definitions(-D_ENABLEHANDHELD)
 endif()
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -250,7 +250,7 @@ void GuiMenu::openEmuELECSettings()
 
 	Window* window = mWindow;
 	std::string a;
-#if !defined(_ENABLEROCKCHIP)
+#if !defined(_ENABLEHANDHELD)
 	auto emuelec_video_mode = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
         std::vector<std::string> videomode;
 		videomode.push_back("1080p60hz");
@@ -4757,7 +4757,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 
 	auto customFeatures = systemData->getCustomFeatures(currentEmulator, currentCore);
 
-#if defined(_ENABLEEMUELEC) && !defined(_ENABLEROCKCHIP)
+#if defined(_ENABLEEMUELEC) && !defined(_ENABLEHANDHELD)
 
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::nativevideo))
 	{

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -250,7 +250,7 @@ void GuiMenu::openEmuELECSettings()
 
 	Window* window = mWindow;
 	std::string a;
-#if !defined(_ENABLEGAMEFORCE) && !defined(ODROIDGOA)
+#if !defined(_ENABLEROCKCHIP)
 	auto emuelec_video_mode = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
         std::vector<std::string> videomode;
 		videomode.push_back("1080p60hz");
@@ -4757,7 +4757,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 
 	auto customFeatures = systemData->getCustomFeatures(currentEmulator, currentCore);
 
-#ifdef _ENABLEEMUELEC
+#if defined(_ENABLEEMUELEC) && !defined(_ENABLEROCKCHIP)
 
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::nativevideo))
 	{


### PR DESCRIPTION
This is only a small change allowing the user to add ENABLE resolution safeguarding for handheld devices. Because pretty much all handheld screens only support one resolution, unless you are taking into account it's hdmi output.
