### PR TITLE
EE-ES Multidisc support.

### DIFF
--- a/es-app/src/guis/GuiGameOptions.cpp
+++ b/es-app/src/guis/GuiGameOptions.cpp
@@ -531,8 +531,8 @@ void GuiGameOptions::createMultidisc(FileData* file)
 	FileData* newFile = new FileData(GAME, newFileName, sourceFile->getSystem());
 
 	auto sys = sourceFile->getSystem();
-	//if (sys->isGroupChildSystem())
-		//sys = sys->getParentGroupSystem();
+	if (sys->isGroupChildSystem())
+		sys = sys->getParentGroupSystem();
 
 	sourceFile->getSystem()->getRootFolder()->addChild(newFile);
 

--- a/es-app/src/guis/GuiGameOptions.cpp
+++ b/es-app/src/guis/GuiGameOptions.cpp
@@ -26,8 +26,11 @@
 #include "SaveStateRepository.h"
 #include "guis/GuiSaveState.h"
 #include "SystemConf.h"
+
+#ifdef _ENABLEEMUELEC
 #include "platform.h"
 #include <regex>
+#endif
 
 GuiGameOptions::GuiGameOptions(Window* window, FileData* game) : GuiComponent(window),
 	mMenu(window, game->getName()), mReloadAll(false)

--- a/es-app/src/guis/GuiGameOptions.cpp
+++ b/es-app/src/guis/GuiGameOptions.cpp
@@ -518,7 +518,7 @@ void GuiGameOptions::createMultidisc(FileData* file)
 
 	auto sourceFile = file->getSourceFileData();
 
-	std::string args = "createMultidisc \""+sourceFile->getSystemName()+"\" \""+sourceFile->getPath()+"\"";
+	std::string args = "createMultidisc \""+sourceFile->getPath()+"\"";
 	args="(/usr/bin/emuelec-utils "+args+")";
 	LOG(LogInfo) << "createMultidisc:" << args;
 	std::stringstream ss(getShOutput(args));

--- a/es-app/src/guis/GuiGameOptions.cpp
+++ b/es-app/src/guis/GuiGameOptions.cpp
@@ -537,7 +537,7 @@ void GuiGameOptions::createMultidisc(FileData* file)
 	sourceFile->getSystem()->getRootFolder()->addChild(newFile);
 
 	// NOT WORKING UNSURE WHY
-	//CollectionSystemManager::get()->refreshCollectionSystems(newFile);
+	CollectionSystemManager::get()->refreshCollectionSystems(newFile);
 
 	auto view = ViewController::get()->getGameListView(sys, false);
 	if (view != nullptr) {

--- a/es-app/src/guis/GuiGameOptions.cpp
+++ b/es-app/src/guis/GuiGameOptions.cpp
@@ -531,10 +531,10 @@ void GuiGameOptions::createMultidisc(FileData* file)
 	FileData* newFile = new FileData(GAME, newFileName, sourceFile->getSystem());
 
 	auto sys = sourceFile->getSystem();
-	if (sys->isGroupChildSystem())
-		sys = sys->getParentGroupSystem();
+	//if (sys->isGroupChildSystem())
+		//sys = sys->getParentGroupSystem();
 
-	sys->getRootFolder()->addChild(newFile);
+	sourceFile->getSystem()->getRootFolder()->addChild(newFile);
 
 	// NOT WORKING UNSURE WHY
 	//CollectionSystemManager::get()->refreshCollectionSystems(newFile);

--- a/es-app/src/guis/GuiGameOptions.h
+++ b/es-app/src/guis/GuiGameOptions.h
@@ -27,6 +27,10 @@ public:
 private:
 	static void deleteGame(FileData* file);
 
+#ifdef _ENABLEEMUELEC
+	static void createMultidisc(FileData* file);
+#endif
+
 	inline void addSaveFunc(const std::function<void()>& func) { mSaveFuncs.push_back(func); };		
 	void openMetaDataEd();
 


### PR DESCRIPTION
Allows the auto creation of m3u files that can contain multiple discs. In order for the game option to show up the initial disc has to have "disc 1" in it (case-insensitive and can be in between brackets). Then as long as the other discs have the same name and are sequential then it will generate a new m3u file and should show up in the gamelist. Launching the m3u should be the same as any other file, but in retroarch it will recognise the file has multiple discs.
I believe dolphin also recognises m3u files.

This depends on the Emuelec function addition "createMultidisc" in emuelec-utils.