### PR TITLE
Resolution fix initial commit.

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -338,7 +338,7 @@ void GuiMenu::openEmuELECSettings()
 			SystemConf::getInstance()->set("ee_videomode", selectedVideoMode);
 			setDisplay(selectedVideoMode);
 			Scripting::fireEvent("quit", "restart");
-			quitES(QuitMode::QUIT);
+			quitES(QuitMode::RESTART);
 		});
 
 		if (emuelec_video_mode->changed()) {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -297,12 +297,12 @@ void GuiMenu::refreshView(Window* window, bool deleteCurrentGui)
 	window->closeSplashScreen();
 	window->renderSplashScreen(_("Refreshing..."));
 
-	/*if (!deleteCurrentGui)
+	if (!deleteCurrentGui)
 	{
 		GuiComponent* topGui = window->peekGui();
 		if (topGui != nullptr)
 			window->removeGui(topGui);
-	}*/
+	}
 
 	GuiComponent *gui;
 	while ((gui = window->peekGui()) != NULL)
@@ -317,11 +317,11 @@ void GuiMenu::refreshView(Window* window, bool deleteCurrentGui)
 
 	ViewController::init(window);
 	
-	//CollectionSystemManager::init(window);		
+	CollectionSystemManager::init(window);		
 	SystemData::loadConfig(window);
 	
-	ViewController::get()->goToSystemView(systemName, true, viewMode);	
-	ViewController::get()->reloadAll(nullptr, false); // Avoid reloading themes a second time
+	//ViewController::get()->goToSystemView(systemName, true, viewMode);	
+	//ViewController::get()->reloadAll(nullptr, false); // Avoid reloading themes a second time
 
 	window->closeSplashScreen();
 	window->pushGui(ViewController::get());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -336,6 +336,7 @@ void GuiMenu::openEmuELECSettings()
 		const std::function<void()> checkDisplay([&, window, selectedVideoMode, defaultResolution] {
 			SystemConf::getInstance()->set("old_videomode", defaultResolution);	
 			SystemConf::getInstance()->set("ee_videomode", selectedVideoMode);
+			SystemConf::getInstance()->saveSystemConf();
 			setDisplay(selectedVideoMode);
 			Scripting::fireEvent("quit", "restart");
 			quitES(QuitMode::RESTART);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -289,44 +289,6 @@ bool sortResolutions (std::string a, std::string b) {
 	return (ia < ib);
 }
 
-void GuiMenu::refreshView(Window* window, bool deleteCurrentGui)
-{
-	auto viewMode = ViewController::get()->getViewMode();
-	auto systemName = ViewController::get()->getSelectedSystem()->getName();
-
-	window->closeSplashScreen();
-	window->renderSplashScreen(_("Refreshing..."));
-
-	if (!deleteCurrentGui)
-	{
-		GuiComponent* topGui = window->peekGui();
-		if (topGui != nullptr)
-			window->removeGui(topGui);
-	}
-
-	GuiComponent *gui;
-	while ((gui = window->peekGui()) != NULL)
-	{
-		window->removeGui(gui);
-
-		//if (gui != sInstance)
-		delete gui;
-	}
-
-	ViewController::deinit();
-
-	ViewController::init(window);
-	
-	CollectionSystemManager::init(window);		
-	SystemData::loadConfig(window);
-	
-	//ViewController::get()->goToSystemView(systemName, true, viewMode);	
-	//ViewController::get()->reloadAll(nullptr, false); // Avoid reloading themes a second time
-
-	window->closeSplashScreen();
-	window->pushGui(ViewController::get());
-}
-
 
 /* < emuelec */
 void GuiMenu::openEmuELECSettings()
@@ -373,13 +335,13 @@ void GuiMenu::openEmuELECSettings()
 
 		const std::function<void()> checkDisplay([&, window, selectedVideoMode] {
 			setDisplay(selectedVideoMode);
-			refreshView(window, true);
+			updateGameLists(window);
 			//Scripting::fireEvent("quit", "restart");
 			//quitES(QuitMode::QUIT);
 
 			const std::function<void()> resetDisplay([&, window] {
 				setDisplay(mDefaultResolution);
-				refreshView(window, true);
+				updateGameLists(window);
 				//Scripting::fireEvent("quit", "restart");
 				//quitES(QuitMode::QUIT);
 				

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -331,10 +331,10 @@ void GuiMenu::openEmuELECSettings()
 
 	s->addSaveFunc([&, emuelec_video_mode, window] {
 		std::string selectedVideoMode = emuelec_video_mode->getSelected();
-		mDefaultResolution = getShOutput(R"(cat /sys/class/display/mode)");
+		std::string defaultResolution = getShOutput(R"(cat /sys/class/display/mode)");
 
-		const std::function<void()> checkDisplay([&, window, selectedVideoMode, mDefaultResolution] {
-			SystemConf::getInstance()->set("old_videomode", mDefaultResolution);	
+		const std::function<void()> checkDisplay([&, window, selectedVideoMode, defaultResolution] {
+			SystemConf::getInstance()->set("old_videomode", defaultResolution);	
 			SystemConf::getInstance()->set("ee_videomode", selectedVideoMode);
 			setDisplay(selectedVideoMode);
 			Scripting::fireEvent("quit", "restart");

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -333,34 +333,12 @@ void GuiMenu::openEmuELECSettings()
 		std::string selectedVideoMode = emuelec_video_mode->getSelected();
 		mDefaultResolution = getShOutput(R"(cat /sys/class/display/mode)");
 
-		const std::function<void()> checkDisplay([&, window, selectedVideoMode] {
+		const std::function<void()> checkDisplay([&, window, selectedVideoMode, mDefaultResolution] {
+			SystemConf::getInstance()->set("old_videomode", mDefaultResolution);	
+			SystemConf::getInstance()->set("ee_videomode", selectedVideoMode);
 			setDisplay(selectedVideoMode);
-			ViewController::get()->reloadAll(window);
-
-			//updateGameLists(window);
-			//window->init(true);
-			//Scripting::fireEvent("quit", "restart");
-			//quitES(QuitMode::QUIT);
-
-			const std::function<void()> resetDisplay([&, window] {
-				setDisplay(mDefaultResolution);
-				ViewController::get()->reloadAll(window);
-				//updateGameLists(window);
-				//Scripting::fireEvent("quit", "restart");
-				//quitES(QuitMode::QUIT);
-				
-				window->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
-			});
-
-			TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(window, _("Is the display set correctly ?"),
-				_("NO"), resetDisplay, _("YES"), [&, selectedVideoMode] {
-					LOG(LogInfo) << "Set video to " << selectedVideoMode;
-					SystemConf::getInstance()->set("ee_videomode", selectedVideoMode);
-					SystemConf::getInstance()->saveSystemConf();
-				});
-			timedMsgBox->setTimedFunc(resetDisplay, 10000);
-
-			window->pushGui(timedMsgBox);
+			Scripting::fireEvent("quit", "restart");
+			quitES(QuitMode::QUIT);
 		});
 
 		if (emuelec_video_mode->changed()) {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -320,7 +320,7 @@ void GuiMenu::openEmuELECSettings()
 		videomode.push_back(def_video);
 	}
 	auto it = unique(videomode.begin(), videomode.end());
-  videomode.resize(distance(videomode.begin(), it));
+	videomode.resize(distance(videomode.begin(), it));
 	std::sort(videomode.begin(), videomode.end(), sortResolutions);
 
 	for (auto it = videomode.cbegin(); it != videomode.cend(); it++) {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -335,15 +335,17 @@ void GuiMenu::openEmuELECSettings()
 
 		const std::function<void()> checkDisplay([&, window, selectedVideoMode] {
 			setDisplay(selectedVideoMode);
-			//updateGameLists(window);
+			window->deinit(false);
 			window->init(true);
+
+			//updateGameLists(window);
+			//window->init(true);
 			//Scripting::fireEvent("quit", "restart");
 			//quitES(QuitMode::QUIT);
 
 			const std::function<void()> resetDisplay([&, window] {
 				setDisplay(mDefaultResolution);
 				//updateGameLists(window);
-				window->init(true);
 				//Scripting::fireEvent("quit", "restart");
 				//quitES(QuitMode::QUIT);
 				

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -326,12 +326,12 @@ void GuiMenu::openEmuELECSettings()
 	for (auto it = videomode.cbegin(); it != videomode.cend(); it++) {
 		emuelec_video_mode->add(*it, *it, SystemConf::getInstance()->get("ee_videomode") == *it);
 	}
+	std::string defaultResolution = SystemConf::getInstance()->get("ee_videomode");
 
 	s->addWithLabel(_("VIDEO MODE"), emuelec_video_mode);
 
-	s->addSaveFunc([&, emuelec_video_mode, window] {
+	s->addSaveFunc([&, emuelec_video_mode, defaultResolution, window] {
 		std::string selectedVideoMode = emuelec_video_mode->getSelected();
-		std::string defaultResolution = getShOutput(R"(cat /sys/class/display/mode)");
 
 		const std::function<void()> checkDisplay([&, window, selectedVideoMode, defaultResolution] {
 			SystemConf::getInstance()->set("old_videomode", defaultResolution);	

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -342,7 +342,11 @@ void GuiMenu::openEmuELECSettings()
 			});
 
 			TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(window, _("Is the display set correctly ?"),
-				_("NO"), nullptr, _("YES"), resetDisplay);
+				_("NO"), resetDisplay, _("YES"), [&, selectedVideoMode] {
+					LOG(LogInfo) << "Set video to " << selectedVideoMode;
+					SystemConf::getInstance()->set("ee_videomode", selectedVideoMode);
+					SystemConf::getInstance()->saveSystemConf();
+				});
 			timedMsgBox->setTimedFunc(resetDisplay, 10000);
 
 			window->pushGui(timedMsgBox);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -309,8 +309,8 @@ void GuiMenu::refreshView(Window* window, bool deleteCurrentGui)
 	{
 		window->removeGui(gui);
 
-		if (gui != sInstance)
-			delete gui;
+		//if (gui != sInstance)
+		delete gui;
 	}
 
 	ViewController::deinit();

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -291,9 +291,6 @@ bool sortResolutions (std::string a, std::string b) {
 
 void GuiMenu::refreshView(Window* window, bool deleteCurrentGui)
 {
-	if (sInstance == nullptr)
-		return;
-
 	auto viewMode = ViewController::get()->getViewMode();
 	auto systemName = ViewController::get()->getSelectedSystem()->getName();
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -335,9 +335,14 @@ void GuiMenu::openEmuELECSettings()
 
 		const std::function<void()> checkDisplay([&, window, selectedVideoMode] {
 			setDisplay(selectedVideoMode);
+			Scripting::fireEvent("quit", "restart");
+			quitES(QuitMode::QUIT);
 
 			const std::function<void()> resetDisplay([&, window] {
 				setDisplay(mDefaultResolution);
+				Scripting::fireEvent("quit", "restart");
+				quitES(QuitMode::QUIT);
+				
 				window->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
 			});
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -289,6 +289,47 @@ bool sortResolutions (std::string a, std::string b) {
 	return (ia < ib);
 }
 
+void GuiMenu::refreshView(Window* window, bool deleteCurrentGui)
+{
+	if (sInstance == nullptr)
+		return;
+
+	auto viewMode = ViewController::get()->getViewMode();
+	auto systemName = ViewController::get()->getSelectedSystem()->getName();
+
+	window->closeSplashScreen();
+	window->renderSplashScreen(_("Loading..."));
+
+	if (!deleteCurrentGui)
+	{
+		GuiComponent* topGui = window->peekGui();
+		if (topGui != nullptr)
+			window->removeGui(topGui);
+	}
+
+	GuiComponent *gui;
+	while ((gui = window->peekGui()) != NULL)
+	{
+		window->removeGui(gui);
+
+		if (gui != sInstance)
+			delete gui;
+	}
+
+	ViewController::deinit();
+
+	ViewController::init(window);
+	
+	//CollectionSystemManager::init(window);		
+	SystemData::loadConfig(window);
+	
+	ViewController::get()->goToSystemView(systemName, true, viewMode);	
+	ViewController::get()->reloadAll(nullptr, false); // Avoid reloading themes a second time
+
+	window->closeSplashScreen();
+	window->pushGui(ViewController::get());
+}
+
 
 /* < emuelec */
 void GuiMenu::openEmuELECSettings()
@@ -335,13 +376,13 @@ void GuiMenu::openEmuELECSettings()
 
 		const std::function<void()> checkDisplay([&, window, selectedVideoMode] {
 			setDisplay(selectedVideoMode);
-			playVideo();
+			refreshView(window, true);
 			//Scripting::fireEvent("quit", "restart");
 			//quitES(QuitMode::QUIT);
 
 			const std::function<void()> resetDisplay([&, window] {
 				setDisplay(mDefaultResolution);
-				playVideo();
+				refreshView(window, true);
 				//Scripting::fireEvent("quit", "restart");
 				//quitES(QuitMode::QUIT);
 				

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -335,13 +335,15 @@ void GuiMenu::openEmuELECSettings()
 
 		const std::function<void()> checkDisplay([&, window, selectedVideoMode] {
 			setDisplay(selectedVideoMode);
-			Scripting::fireEvent("quit", "restart");
-			quitES(QuitMode::QUIT);
+			playVideo();
+			//Scripting::fireEvent("quit", "restart");
+			//quitES(QuitMode::QUIT);
 
 			const std::function<void()> resetDisplay([&, window] {
 				setDisplay(mDefaultResolution);
-				Scripting::fireEvent("quit", "restart");
-				quitES(QuitMode::QUIT);
+				playVideo();
+				//Scripting::fireEvent("quit", "restart");
+				//quitES(QuitMode::QUIT);
 				
 				window->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
 			});

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -336,14 +336,14 @@ void GuiMenu::openEmuELECSettings()
 		const std::function<void()> checkDisplay([&, window, selectedVideoMode] {
 			setDisplay(selectedVideoMode);
 			//updateGameLists(window);
-			window.init(true)
+			window->init(true);
 			//Scripting::fireEvent("quit", "restart");
 			//quitES(QuitMode::QUIT);
 
 			const std::function<void()> resetDisplay([&, window] {
 				setDisplay(mDefaultResolution);
 				//updateGameLists(window);
-				window.init(true)
+				window->init(true);
 				//Scripting::fireEvent("quit", "restart");
 				//quitES(QuitMode::QUIT);
 				

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -302,7 +302,7 @@ void GuiMenu::refreshView(Window* window, bool deleteCurrentGui)
 		GuiComponent* topGui = window->peekGui();
 		if (topGui != nullptr)
 			window->removeGui(topGui);
-	}
+	}*/
 
 	GuiComponent *gui;
 	while ((gui = window->peekGui()) != NULL)
@@ -311,14 +311,14 @@ void GuiMenu::refreshView(Window* window, bool deleteCurrentGui)
 
 		//if (gui != sInstance)
 		delete gui;
-	}*/
+	}
 
 	ViewController::deinit();
 
 	ViewController::init(window);
 	
 	//CollectionSystemManager::init(window);		
-	//SystemData::loadConfig(window);
+	SystemData::loadConfig(window);
 	
 	//ViewController::get()->goToSystemView(systemName, true, viewMode);	
 	//ViewController::get()->reloadAll(nullptr, false); // Avoid reloading themes a second time

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -295,9 +295,9 @@ void GuiMenu::refreshView(Window* window, bool deleteCurrentGui)
 	auto systemName = ViewController::get()->getSelectedSystem()->getName();
 
 	window->closeSplashScreen();
-	window->renderSplashScreen(_("Loading..."));
+	window->renderSplashScreen(_("Refreshing..."));
 
-	if (!deleteCurrentGui)
+	/*if (!deleteCurrentGui)
 	{
 		GuiComponent* topGui = window->peekGui();
 		if (topGui != nullptr)
@@ -311,17 +311,17 @@ void GuiMenu::refreshView(Window* window, bool deleteCurrentGui)
 
 		//if (gui != sInstance)
 		delete gui;
-	}
+	}*/
 
 	ViewController::deinit();
 
 	ViewController::init(window);
 	
 	//CollectionSystemManager::init(window);		
-	SystemData::loadConfig(window);
+	//SystemData::loadConfig(window);
 	
-	ViewController::get()->goToSystemView(systemName, true, viewMode);	
-	ViewController::get()->reloadAll(nullptr, false); // Avoid reloading themes a second time
+	//ViewController::get()->goToSystemView(systemName, true, viewMode);	
+	//ViewController::get()->reloadAll(nullptr, false); // Avoid reloading themes a second time
 
 	window->closeSplashScreen();
 	window->pushGui(ViewController::get());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -243,6 +243,53 @@ if (!isKidUI)
 	}
 }
 #ifdef _ENABLEEMUELEC
+
+void setDisplay (std::string resolution) {
+	LOG(LogInfo) << "Setting video to " << resolution;
+	runSystemCommand("/usr/bin/setres.sh " + resolution, "", nullptr);
+}
+
+int getResWidth (std::string res)
+{
+	std::string tmp = "";
+	std::size_t pos = res.find("x");
+
+	if (pos != std::string::npos) {
+		tmp = res.substr(0, pos);
+		return atoi( tmp.c_str() );
+	}
+	pos = res.find("p");
+	if (pos != std::string::npos) {
+		tmp = res.substr(0, pos);
+		int resv = atoi(tmp.c_str());
+		return std::ceil(( (float)16 / 9 * resv));
+	}
+	pos = res.find("i");
+	if (pos != std::string::npos) {
+		tmp = res.substr(0, pos);
+		int resv = atoi(tmp.c_str());
+		return std::ceil(( (float)16 / 9 * resv));
+	}
+	return 0;
+}
+
+int getHzFromRes(std::string res)
+{
+	int tmp = atoi(res.substr(res.length()-4, 2).c_str());
+	if (tmp > 0) return tmp;
+	return 60;
+}
+
+bool sortResolutions (std::string a, std::string b) {
+	int ia = getResWidth(a);
+	int ib = getResWidth(b);
+
+	if (ia == ib) return (getHzFromRes(a) < getHzFromRes(b));
+
+	return (ia < ib);
+}
+
+
 /* < emuelec */
 void GuiMenu::openEmuELECSettings()
 {
@@ -252,76 +299,74 @@ void GuiMenu::openEmuELECSettings()
 	std::string a;
 #if !defined(_ENABLEGAMEFORCE) && !defined(ODROIDGOA)
 	auto emuelec_video_mode = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
-        std::vector<std::string> videomode;
-		videomode.push_back("1080p60hz");
-		videomode.push_back("1080i60hz");
-		videomode.push_back("720p60hz");
-		videomode.push_back("720p50hz");
-		videomode.push_back("480p60hz");
-		videomode.push_back("480cvbs");
-		videomode.push_back("576p50hz");
-		videomode.push_back("1080p50hz");
-		videomode.push_back("1080i50hz");
-		videomode.push_back("576cvbs");
-		videomode.push_back("Custom");
-		videomode.push_back("-- AUTO-DETECTED RESOLUTIONS --");
-   for(std::stringstream ss(getShOutput(R"(/usr/bin/emuelec-utils resolutions)")); getline(ss, a, ','); ) {
-        videomode.push_back(a);
+  std::vector<std::string> videomode;
+
+	videomode.push_back("1080p60hz");
+	videomode.push_back("1080i60hz");
+	videomode.push_back("720p60hz");
+	videomode.push_back("720p50hz");
+	videomode.push_back("480p60hz");
+	videomode.push_back("480cvbs");
+	videomode.push_back("576p50hz");
+	videomode.push_back("1080p50hz");
+	videomode.push_back("1080i50hz");
+	videomode.push_back("576cvbs");
+
+	std::string def_video;
+	std::stringstream ss(getShOutput(R"(/usr/bin/emuelec-utils resolutions)"));
+	while(ss.good()) {
+		def_video="";
+		getline(ss, def_video, ',');
+		videomode.push_back(def_video);
 	}
-		for (auto it = videomode.cbegin(); it != videomode.cend(); it++) {
-		emuelec_video_mode->add(*it, *it, SystemConf::getInstance()->get("ee_videomode") == *it); }
-		s->addWithLabel(_("VIDEO MODE"), emuelec_video_mode);
-	   	
-		s->addSaveFunc([this, emuelec_video_mode, window] {
-		
-		//bool v_need_reboot = false;
-	
+	auto it = unique(videomode.begin(), videomode.end());
+  videomode.resize(distance(videomode.begin(), it));
+	std::sort(videomode.begin(), videomode.end(), sortResolutions);
+
+	for (auto it = videomode.cbegin(); it != videomode.cend(); it++) {
+		emuelec_video_mode->add(*it, *it, SystemConf::getInstance()->get("ee_videomode") == *it);
+	}
+
+	s->addWithLabel(_("VIDEO MODE"), emuelec_video_mode);
+
+	s->addSaveFunc([&, emuelec_video_mode, window] {
+		std::string selectedVideoMode = emuelec_video_mode->getSelected();
+		mDefaultResolution = getShOutput(R"(cat /sys/class/display/mode)");
+
+		const std::function<void()> checkDisplay([&, window, selectedVideoMode] {
+			setDisplay(selectedVideoMode);
+
+			const std::function<void()> resetDisplay([&, window] {
+				setDisplay(mDefaultResolution);
+				window->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
+			});
+
+			TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(window, _("Is the display set correctly ?"),
+				_("NO"), nullptr, _("YES"), resetDisplay);
+			timedMsgBox->setTimedFunc(resetDisplay, 10000);
+
+			window->pushGui(timedMsgBox);
+		});
+
 		if (emuelec_video_mode->changed()) {
-			std::string selectedVideoMode = emuelec_video_mode->getSelected();
-		if (emuelec_video_mode->getSelected() != "-- AUTO-DETECTED RESOLUTIONS --") { 
-			if (emuelec_video_mode->getSelected() != "Custom") {
 			std::string msg = _("You are about to set EmuELEC resolution to:") +"\n" + selectedVideoMode + "\n";
 			msg += _("Do you want to proceed ?");
-		
+
 			window->pushGui(new GuiMsgBox(window, msg,
-				_("YES"), [selectedVideoMode] {
-					runSystemCommand("echo "+selectedVideoMode+" > /sys/class/display/mode", "", nullptr);
-					SystemConf::getInstance()->set("ee_videomode", selectedVideoMode);
-					LOG(LogInfo) << "Setting video to " << selectedVideoMode;
-					runSystemCommand("/usr/bin/setres.sh", "", nullptr);
-					SystemConf::getInstance()->saveSystemConf();
-				//	v_need_reboot = true;
-				}, _("NO"),nullptr));
-		
-		} else { 
+				_("YES"), checkDisplay, _("NO"), nullptr));
+		}
+		else {
 			if(Utils::FileSystem::exists("/storage/.config/EE_VIDEO_MODE")) {
-				runSystemCommand("echo $(cat /storage/.config/EE_VIDEO_MODE) > /sys/class/display/mode", "", nullptr);
-				LOG(LogInfo) << "Setting custom video mode from /storage/.config/EE_VIDEO_MODE to " << runSystemCommand("cat /storage/.config/EE_VIDEO_MODE", "", nullptr);
-				SystemConf::getInstance()->set("ee_videomode", selectedVideoMode);
-				SystemConf::getInstance()->saveSystemConf();
-				//v_need_reboot = true;
-			} else { 
-				if(Utils::FileSystem::exists("/flash/EE_VIDEO_MODE")) {
-				runSystemCommand("echo $(cat /flash/EE_VIDEO_MODE) > /sys/class/display/mode", "", nullptr);
-				LOG(LogInfo) << "Setting custom video mode from /flash/EE_VIDEO_MODE to " << runSystemCommand("cat /flash/EE_VIDEO_MODE", "", nullptr);
-				SystemConf::getInstance()->set("ee_videomode", selectedVideoMode);
-				SystemConf::getInstance()->saveSystemConf();
-				//v_need_reboot = true;
-					} else {
-					runSystemCommand("echo " + SystemConf::getInstance()->get("ee_videomode")+ " > /sys/class/display/mode", "", nullptr);
-					std::string msg = "/storage/.config/EE_VIDEO_MODE or /flash/EE_VIDEO_MODE not found";
-					window->pushGui(new GuiMsgBox(window, msg,
-				"OK", [selectedVideoMode] {
-					LOG(LogInfo) << "EE_VIDEO_MODE was not found! Setting video mode to " + SystemConf::getInstance()->get("ee_videomode");
-			}));
-					}
-				}
+				selectedVideoMode = getShOutput(R"(cat /storage/.config/EE_VIDEO_MODE)");
+				checkDisplay();
 			}
-		   }	
-			//if (v_need_reboot)
-		 	mWindow->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
-		 }
-		});
+			else if(Utils::FileSystem::exists("/flash/EE_VIDEO_MODE")) {
+				selectedVideoMode = getShOutput(R"(cat /flash/EE_VIDEO_MODE)");
+				checkDisplay();
+		  }
+		}
+	});
+
 #endif
 #ifdef _ENABLEGAMEFORCE
 		auto emuelec_blrgboptions_def = std::make_shared< OptionListComponent<std::string> >(mWindow, "BUTTON LED COLOR", false);
@@ -4765,18 +4810,27 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		systemConfiguration->addWithLabel(_("NATIVE VIDEO"), videoNativeResolutionMode_choice);
 
 		const std::function<void()> video_changed([mWindow, configName, videoNativeResolutionMode_choice] {
-
-			std::string def_video;
 			std::string video_choice = videoNativeResolutionMode_choice->getSelected();
 			bool safe_video = false;
 
-			if (video_choice == "auto")
+			if (video_choice.empty() || video_choice == "auto") {
 				safe_video = true;
+			}
 			else {
-				for(std::stringstream ss(getShOutput(R"(/usr/bin/emuelec-utils resolutions)")); getline(ss, def_video, ','); ) {
-					if (video_choice == def_video) {
-						safe_video = true;
-						break;
+				std::stringstream ss(getShOutput(R"(/usr/bin/emuelec-utils resolutions)"));
+				ss.seekg(0, std::ios::end);
+				long length = ss.tellg();
+				LOG(LogInfo) << "NATIVEVIDEO - RESOLUTIONS LENGTH: " << length;
+				if (length > 0) {
+					ss.seekg(0, std::ios::beg);
+					while (ss.good()) {
+						std::string def_video;
+						getline(ss, def_video, ',');
+						if (def_video.find(video_choice) != std::string::npos) {
+							LOG(LogInfo) << "NATIVEVIDEO - DEF_VIDEO_FOUND: " << def_video << " : " << video_choice;
+							safe_video = true;
+							break;
+						}
 					}
 				}
 			}
@@ -5374,46 +5428,6 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createRatioOptionList
 
 #ifdef _ENABLEEMUELEC
 
-int getResWidth (std::string res)
-{
-	std::string tmp = "";
-	std::size_t pos = res.find("x");
-
-	if (pos != std::string::npos) {
-		tmp = res.substr(0, pos);
-		return atoi( tmp.c_str() );
-	}
-	pos = res.find("p");
-	if (pos != std::string::npos) {
-		tmp = res.substr(0, pos);
-		int resv = atoi(tmp.c_str());
-		return std::ceil(( (float)16 / 9 * resv));
-	}
-	pos = res.find("i");
-	if (pos != std::string::npos) {
-		tmp = res.substr(0, pos);
-		int resv = atoi(tmp.c_str());
-		return std::ceil(( (float)16 / 9 * resv));
-	}
-	return 0;
-}
-
-int getHzFromRes(std::string res)
-{
-	int tmp = atoi(res.substr(res.length()-4, 2).c_str());
-	if (tmp > 0) return tmp;
-	return 60;
-}
-
-bool sortResolutions (std::string a, std::string b) {
-	int ia = getResWidth(a);
-	int ib = getResWidth(b);
-	
-	if (ia == ib) return (getHzFromRes(a) < getHzFromRes(b));
-	
-	return (ia < ib);
-}
-
 std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createNativeVideoResolutionModeOptionList(Window *window, std::string configname)
 {
 	auto emuelec_video_mode = std::make_shared< OptionListComponent<std::string> >(window, "NATIVE VIDEO", false);
@@ -5429,13 +5443,15 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createNativeVideoReso
 	videomode.push_back("1080i60hz");
 	videomode.push_back("1080p60hz");
 
-	std::string def_video;
-	for(std::stringstream ss(getShOutput(R"(/usr/bin/emuelec-utils resolutions)")); getline(ss, def_video, ','); ) {
-		if (!std::count(videomode.begin(), videomode.end(), def_video)) {
-			 videomode.push_back(def_video);
-		}
+	std::string def_video = "";
+	std::stringstream ss(getShOutput(R"(/usr/bin/emuelec-utils resolutions)"));
+	while(ss.good()) {
+		def_video = "";
+		getline(ss, def_video, ',');
+		videomode.push_back(def_video);
 	}
-
+	auto it = unique(videomode.begin(), videomode.end());
+  videomode.resize(distance(videomode.begin(), it));
 	std::sort(videomode.begin(), videomode.end(), sortResolutions);
 
 	std::string index = SystemConf::getInstance()->get(configname + ".nativevideo");

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -299,7 +299,7 @@ void GuiMenu::openEmuELECSettings()
 	std::string a;
 #if !defined(_ENABLEGAMEFORCE) && !defined(ODROIDGOA)
 	auto emuelec_video_mode = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
-  std::vector<std::string> videomode;
+	std::vector<std::string> videomode;
 
 	videomode.push_back("1080p60hz");
 	videomode.push_back("1080i60hz");

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -246,7 +246,7 @@ if (!isKidUI)
 
 void setDisplay (std::string resolution) {
 	LOG(LogInfo) << "Setting video to " << resolution;
-	runSystemCommand("/usr/bin/setres.sh " + resolution, "", nullptr);
+	runSystemCommand("setres.sh " + resolution, "", nullptr);
 }
 
 int getResWidth (std::string res)

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -335,8 +335,7 @@ void GuiMenu::openEmuELECSettings()
 
 		const std::function<void()> checkDisplay([&, window, selectedVideoMode] {
 			setDisplay(selectedVideoMode);
-			window->deinit(false);
-			window->init(true);
+			ViewController::get()->reloadAll(window);
 
 			//updateGameLists(window);
 			//window->init(true);
@@ -345,6 +344,7 @@ void GuiMenu::openEmuELECSettings()
 
 			const std::function<void()> resetDisplay([&, window] {
 				setDisplay(mDefaultResolution);
+				ViewController::get()->reloadAll(window);
 				//updateGameLists(window);
 				//Scripting::fireEvent("quit", "restart");
 				//quitES(QuitMode::QUIT);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -5451,7 +5451,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createNativeVideoReso
 		videomode.push_back(def_video);
 	}
 	auto it = unique(videomode.begin(), videomode.end());
-  videomode.resize(distance(videomode.begin(), it));
+	videomode.resize(distance(videomode.begin(), it));
 	std::sort(videomode.begin(), videomode.end(), sortResolutions);
 
 	std::string index = SystemConf::getInstance()->get(configname + ".nativevideo");

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -320,8 +320,8 @@ void GuiMenu::refreshView(Window* window, bool deleteCurrentGui)
 	//CollectionSystemManager::init(window);		
 	SystemData::loadConfig(window);
 	
-	//ViewController::get()->goToSystemView(systemName, true, viewMode);	
-	//ViewController::get()->reloadAll(nullptr, false); // Avoid reloading themes a second time
+	ViewController::get()->goToSystemView(systemName, true, viewMode);	
+	ViewController::get()->reloadAll(nullptr, false); // Avoid reloading themes a second time
 
 	window->closeSplashScreen();
 	window->pushGui(ViewController::get());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -335,13 +335,15 @@ void GuiMenu::openEmuELECSettings()
 
 		const std::function<void()> checkDisplay([&, window, selectedVideoMode] {
 			setDisplay(selectedVideoMode);
-			updateGameLists(window);
+			//updateGameLists(window);
+			window.init(true)
 			//Scripting::fireEvent("quit", "restart");
 			//quitES(QuitMode::QUIT);
 
 			const std::function<void()> resetDisplay([&, window] {
 				setDisplay(mDefaultResolution);
-				updateGameLists(window);
+				//updateGameLists(window);
+				window.init(true)
 				//Scripting::fireEvent("quit", "restart");
 				//quitES(QuitMode::QUIT);
 				

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -67,7 +67,6 @@ private:
 #ifdef _ENABLEEMUELEC
     std::string mDefaultResolution;
 
-    void refreshView(Window* window, bool deleteCurrentGui);
 	  void openEmuELECSettings(); /* < emuelec */
     static void openDangerZone(Window* mWindow, std::string configName);
     static void createGamepadConfig(Window* window, GuiSettings* systemConfiguration);

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -67,6 +67,7 @@ private:
 #ifdef _ENABLEEMUELEC
     std::string mDefaultResolution;
 
+    void refreshView(Window* window, bool deleteCurrentGui);
 	  void openEmuELECSettings(); /* < emuelec */
     static void openDangerZone(Window* mWindow, std::string configName);
     static void createGamepadConfig(Window* window, GuiSettings* systemConfiguration);

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -65,7 +65,9 @@ private:
 	void openUISettings();
 	void openUpdatesSettings();
 #ifdef _ENABLEEMUELEC
-	void openEmuELECSettings(); /* < emuelec */
+    std::string mDefaultResolution;
+
+	  void openEmuELECSettings(); /* < emuelec */
     static void openDangerZone(Window* mWindow, std::string configName);
     static void createGamepadConfig(Window* window, GuiSettings* systemConfiguration);
     static void openExternalMounts(Window* mWindow, std::string configName);

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -65,8 +65,6 @@ private:
 	void openUISettings();
 	void openUpdatesSettings();
 #ifdef _ENABLEEMUELEC
-    std::string mDefaultResolution;
-
 	  void openEmuELECSettings(); /* < emuelec */
     static void openDangerZone(Window* mWindow, std::string configName);
     static void createGamepadConfig(Window* window, GuiSettings* systemConfiguration);

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -682,6 +682,36 @@ void SystemView::update(int deltaTime)
 		else
 			showQuickSearch();
 	}
+
+	if (deltaTime > 1000)
+	{
+		std::string oldMode = SystemConf::getInstance()->get("old_videomode");
+		std::string newMode = SystemConf::getInstance()->get("ee_videomode");
+		SystemConf::getInstance()->set("old_videomode", "");
+		SystemConf::getInstance()->saveSystemConf();
+		if (!oldMode.empty() && newMode != oldMode)
+		{
+			const std::function<void()> resetDisplay([&, oldMode] {
+				LOG(LogInfo) << "Reverting video to " << oldMode;
+				runSystemCommand("setres.sh " + oldMode, "", nullptr);
+				SystemConf::getInstance()->set("ee_videomode", oldMode);
+				//SystemConf::getInstance()->set("old_videomode", "");
+				SystemConf::getInstance()->saveSystemConf();
+				mWindow->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
+				Scripting::fireEvent("quit", "restart");
+				quitES(QuitMode::RESTART);		
+			});
+
+			TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(mWindow, _("Is the display set correctly ?"),
+				_("NO"), resetDisplay, _("YES"), [&, newMode] {
+					LOG(LogInfo) << "Set video to " << newMode;
+					SystemConf::getInstance()->set("ee_videomode", newMode);	
+					SystemConf::getInstance()->saveSystemConf();
+				});
+			timedMsgBox->setTimedFunc(resetDisplay, 10000);
+			mWindow->pushGui(timedMsgBox);
+		}			
+	}
 }
 
 void SystemView::updateExtraTextBinding()
@@ -1741,32 +1771,6 @@ void SystemView::onShow()
 
 	if (getSelected() != nullptr)
 		TextToSpeech::getInstance()->say(getSelected()->getFullName());
-
-	std::string oldMode = SystemConf::getInstance()->get("old_videomode");
-	std::string newMode = SystemConf::getInstance()->get("ee_videomode");
-	if (!oldMode.empty() && newMode != oldMode)
-	{
-		const std::function<void()> resetDisplay([&, oldMode] {
-			LOG(LogInfo) << "Reverting video to " << oldMode;
-			runSystemCommand("setres.sh " + oldMode, "", nullptr);
-			SystemConf::getInstance()->set("ee_videomode", oldMode);
-			SystemConf::getInstance()->set("old_videomode", "");
-			SystemConf::getInstance()->saveSystemConf();
-			mWindow->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
-			Scripting::fireEvent("quit", "restart");
-			quitES(QuitMode::RESTART);		
-		});
-
-		TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(mWindow, _("Is the display set correctly ?"),
-			_("NO"), resetDisplay, _("YES"), [&, newMode] {
-				LOG(LogInfo) << "Set video to " << newMode;
-				SystemConf::getInstance()->set("ee_videomode", newMode);
-				SystemConf::getInstance()->set("old_videomode", "");
-				SystemConf::getInstance()->saveSystemConf();
-			});
-		timedMsgBox->setTimedFunc(resetDisplay, 10000);
-		mWindow->pushGui(timedMsgBox);
-	}	
 }
 
 void SystemView::onHide()

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -1741,6 +1741,30 @@ void SystemView::onShow()
 	if (getSelected() != nullptr)
 		TextToSpeech::getInstance()->say(getSelected()->getFullName());
 
+	std::string oldMode = SystemConf::getInstance()->get("old_videomode");
+	std::string newMode = SystemConf::getInstance()->get("ee_videomode");
+	if (!oldMode.empty() && newMode != oldMode)
+	{
+		const std::function<void()> resetDisplay([&, oldMode] {
+			LOG(LogInfo) << "Reverting video to " << oldMode;
+			runSystemCommand("/usr/bin/setres.sh " + oldMode, "", nullptr);
+			SystemConf::getInstance()->set("ee_videomode", oldMode);
+			SystemConf::getInstance()->set("old_videomode", "");
+			SystemConf::getInstance()->saveSystemConf();
+			mWindow->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
+			Scripting::fireEvent("quit", "restart");
+			quitES(QuitMode::RESTART);		
+		});
+
+		TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(mWindow, _("Is the display set correctly ?"),
+			_("NO"), resetDisplay, _("YES"), [&, newMode] {
+				LOG(LogInfo) << "Set video to " << newMode;
+				SystemConf::getInstance()->set("ee_videomode", newMode);
+				SystemConf::getInstance()->saveSystemConf();
+			});
+		timedMsgBox->setTimedFunc(resetDisplay, 10000);
+		mWindow->pushGui(timedMsgBox);
+	}
 }
 
 void SystemView::onHide()

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -304,6 +304,35 @@ void SystemView::populate()
 			mWindow->pushGui(new GuiMsgBox(mWindow, _("ERROR: EVERY SYSTEM IS HIDDEN, RE-DISPLAYING ALL OF THEM NOW"), _("OK"), nullptr));
 		}
 	}
+	
+	
+	std::string oldMode = SystemConf::getInstance()->get("old_videomode");
+	std::string newMode = SystemConf::getInstance()->get("ee_videomode");
+	SystemConf::getInstance()->set("old_videomode", "");
+	SystemConf::getInstance()->saveSystemConf();
+	if (!oldMode.empty() && newMode != oldMode)
+	{
+		const std::function<void()> resetDisplay([&, oldMode] {
+			LOG(LogInfo) << "Reverting video to " << oldMode;
+			runSystemCommand("setres.sh " + oldMode, "", nullptr);
+			SystemConf::getInstance()->set("ee_videomode", oldMode);
+			SystemConf::getInstance()->saveSystemConf();
+			mWindow->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
+			Scripting::fireEvent("quit", "restart");
+			quitES(QuitMode::RESTART);		
+		});
+
+		TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(mWindow, _("Is the display set correctly ?"),
+			_("NO"), resetDisplay, _("YES"), [&, newMode] {
+				LOG(LogInfo) << "Set video to " << newMode;
+				SystemConf::getInstance()->set("ee_videomode", newMode);	
+				SystemConf::getInstance()->saveSystemConf();
+			});
+		timedMsgBox->setTimedFunc(resetDisplay, 10000);
+
+		populate();
+		mWindow->pushGui(timedMsgBox);
+	}		
 }
 
 void SystemView::goToSystem(SystemData* system, bool animate)
@@ -681,36 +710,6 @@ void SystemView::update(int deltaTime)
 			setCursor(SystemData::getRandomSystem());
 		else
 			showQuickSearch();
-	}
-
-	if (deltaTime > 1000)
-	{
-		std::string oldMode = SystemConf::getInstance()->get("old_videomode");
-		std::string newMode = SystemConf::getInstance()->get("ee_videomode");
-		SystemConf::getInstance()->set("old_videomode", "");
-		SystemConf::getInstance()->saveSystemConf();
-		if (!oldMode.empty() && newMode != oldMode)
-		{
-			const std::function<void()> resetDisplay([&, oldMode] {
-				LOG(LogInfo) << "Reverting video to " << oldMode;
-				runSystemCommand("setres.sh " + oldMode, "", nullptr);
-				SystemConf::getInstance()->set("ee_videomode", oldMode);
-				//SystemConf::getInstance()->set("old_videomode", "");
-				SystemConf::getInstance()->saveSystemConf();
-				mWindow->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
-				Scripting::fireEvent("quit", "restart");
-				quitES(QuitMode::RESTART);		
-			});
-
-			TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(mWindow, _("Is the display set correctly ?"),
-				_("NO"), resetDisplay, _("YES"), [&, newMode] {
-					LOG(LogInfo) << "Set video to " << newMode;
-					SystemConf::getInstance()->set("ee_videomode", newMode);	
-					SystemConf::getInstance()->saveSystemConf();
-				});
-			timedMsgBox->setTimedFunc(resetDisplay, 10000);
-			mWindow->pushGui(timedMsgBox);
-		}			
 	}
 }
 

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -31,7 +31,7 @@ const int logoBuffersLeft[] = { -5, -2, -1 };
 const int logoBuffersRight[] = { 1, 2, 5 };
 
 #ifdef _ENABLEEMUELEC	
-		#define CHECK_RESOLUTION_DELAY 3000
+		#define CHECK_RESOLUTION_DELAY 2000
 #endif
 
 SystemView::SystemView(Window* window) : IList<SystemViewData, SystemData*>(window, LIST_SCROLL_STYLE_SLOW, LIST_ALWAYS_LOOP),

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -329,8 +329,6 @@ void SystemView::populate()
 				SystemConf::getInstance()->saveSystemConf();
 			});
 		timedMsgBox->setTimedFunc(resetDisplay, 10000);
-
-		populate();
 		mWindow->pushGui(timedMsgBox);
 	}		
 }

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -1018,31 +1018,6 @@ void SystemView::render(const Transform4x4f& parentTrans)
 	}
 
 	renderExtras(trans, minMax.second, INT16_MAX);
-
-	std::string oldMode = SystemConf::getInstance()->get("old_videomode");
-	std::string newMode = SystemConf::getInstance()->get("ee_videomode");
-	if (!oldMode.empty() && newMode != oldMode)
-	{
-		const std::function<void()> resetDisplay([&, oldMode] {
-			LOG(LogInfo) << "Reverting video to " << oldMode;
-			runSystemCommand("/usr/bin/setres.sh " + oldMode, "", nullptr);
-			SystemConf::getInstance()->set("ee_videomode", oldMode);
-			SystemConf::getInstance()->set("old_videomode", "");
-			SystemConf::getInstance()->saveSystemConf();
-			mWindow->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
-			Scripting::fireEvent("quit", "restart");
-			quitES(QuitMode::RESTART);		
-		});
-
-		TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(mWindow, _("Is the display set correctly ?"),
-			_("NO"), resetDisplay, _("YES"), [&, newMode] {
-				LOG(LogInfo) << "Set video to " << newMode;
-				SystemConf::getInstance()->set("ee_videomode", newMode);
-				SystemConf::getInstance()->saveSystemConf();
-			});
-		timedMsgBox->setTimedFunc(resetDisplay, 10000);
-		mWindow->pushGui(timedMsgBox);
-	}	
 }
 
 std::vector<HelpPrompt> SystemView::getHelpPrompts()
@@ -1766,6 +1741,32 @@ void SystemView::onShow()
 
 	if (getSelected() != nullptr)
 		TextToSpeech::getInstance()->say(getSelected()->getFullName());
+
+	std::string oldMode = SystemConf::getInstance()->get("old_videomode");
+	std::string newMode = SystemConf::getInstance()->get("ee_videomode");
+	if (!oldMode.empty() && newMode != oldMode)
+	{
+		const std::function<void()> resetDisplay([&, oldMode] {
+			LOG(LogInfo) << "Reverting video to " << oldMode;
+			runSystemCommand("setres.sh " + oldMode, "", nullptr);
+			SystemConf::getInstance()->set("ee_videomode", oldMode);
+			SystemConf::getInstance()->set("old_videomode", "");
+			SystemConf::getInstance()->saveSystemConf();
+			mWindow->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
+			Scripting::fireEvent("quit", "restart");
+			quitES(QuitMode::RESTART);		
+		});
+
+		TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(mWindow, _("Is the display set correctly ?"),
+			_("NO"), resetDisplay, _("YES"), [&, newMode] {
+				LOG(LogInfo) << "Set video to " << newMode;
+				SystemConf::getInstance()->set("ee_videomode", newMode);
+				SystemConf::getInstance()->set("old_videomode", "");
+				SystemConf::getInstance()->saveSystemConf();
+			});
+		timedMsgBox->setTimedFunc(resetDisplay, 10000);
+		mWindow->pushGui(timedMsgBox);
+	}	
 }
 
 void SystemView::onHide()

--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -24,6 +24,7 @@
 #include "guis/GuiTextEditPopup.h"
 #include "guis/GuiTextEditPopupKeyboard.h"
 #include "TextToSpeech.h"
+#include "platform.h"
 
 // buffer values for scrolling velocity (left, stopped, right)
 const int logoBuffersLeft[] = { -5, -2, -1 };

--- a/es-app/src/views/SystemView.h
+++ b/es-app/src/views/SystemView.h
@@ -72,6 +72,11 @@ public:
 	void update(int deltaTime) override;
 	void render(const Transform4x4f& parentTrans) override;
 
+#ifdef _ENABLEEMUELEC
+	int mCheckResTime;
+	void checkResolutionSwitch();
+#endif
+
 	void onThemeChanged(const std::shared_ptr<ThemeData>& theme);
 
 	std::vector<HelpPrompt> getHelpPrompts() override;

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -131,25 +131,25 @@ void ViewController::goToStart(bool forceImmediate)
 
 	if (!oldMode.empty() && newMode != oldMode)
 	{
-		const std::function<void()> resetDisplay([&, mWindow, oldMode] {
+		const std::function<void()> resetDisplay([&, oldMode] {
 			LOG(LogInfo) << "Reverting video to " << oldMode;
 			runSystemCommand("/usr/bin/setres.sh " + oldMode, "", nullptr);
 			SystemConf::getInstance()->set("ee_videomode", oldMode);
 			SystemConf::getInstance()->set("old_videomode", "");
 			SystemConf::getInstance()->saveSystemConf();
-			mWindow->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
+			displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
 			Scripting::fireEvent("quit", "restart");
 			quitES(QuitMode::RESTART);		
 		});
 
-		TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(mWindow, _("Is the display set correctly ?"),
+		TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(this, _("Is the display set correctly ?"),
 			_("NO"), resetDisplay, _("YES"), [&, newMode] {
 				LOG(LogInfo) << "Set video to " << newMode;
 				SystemConf::getInstance()->set("ee_videomode", newMode);
 				SystemConf::getInstance()->saveSystemConf();
 			});
 		timedMsgBox->setTimedFunc(resetDisplay, 10000);
-		mWindow->pushGui(timedMsgBox);
+		pushGui(timedMsgBox);
 	}
 }
 

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -1281,33 +1281,6 @@ void ViewController::onShow()
 {
 	if (mCurrentView)
 		mCurrentView->onShow();
-		
-	std::string oldMode = SystemConf::getInstance()->get("old_videomode");
-	std::string newMode = SystemConf::getInstance()->get("ee_videomode");
-	oldMode = "720p60hz";
-	newMode = "1080p60hz";
-	if (!oldMode.empty() && newMode != oldMode)
-	{
-		const std::function<void()> resetDisplay([&, oldMode] {
-			LOG(LogInfo) << "Reverting video to " << oldMode;
-			runSystemCommand("/usr/bin/setres.sh " + oldMode, "", nullptr);
-			SystemConf::getInstance()->set("ee_videomode", oldMode);
-			SystemConf::getInstance()->set("old_videomode", "");
-			SystemConf::getInstance()->saveSystemConf();
-			mWindow->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
-			Scripting::fireEvent("quit", "restart");
-			quitES(QuitMode::RESTART);		
-		});
-
-		TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(mWindow, _("Is the display set correctly ?"),
-			_("NO"), resetDisplay, _("YES"), [&, newMode] {
-				LOG(LogInfo) << "Set video to " << newMode;
-				SystemConf::getInstance()->set("ee_videomode", newMode);
-				SystemConf::getInstance()->saveSystemConf();
-			});
-		timedMsgBox->setTimedFunc(resetDisplay, 10000);
-		mWindow->pushGui(timedMsgBox);
-	}
 }
 
 void ViewController::onScreenSaverActivate()

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -56,32 +56,7 @@ void ViewController::init(Window* window)
 		delete sInstance;
 
 	sInstance = new ViewController(window);
-	
-	std::string oldMode = SystemConf::getInstance()->get("old_videomode");
-	std::string newMode = SystemConf::getInstance()->get("ee_videomode");
 
-	if (!oldMode.empty() && newMode != oldMode)
-	{
-		const std::function<void()> resetDisplay([&, window, oldMode] {
-			LOG(LogInfo) << "Reverting video to " << oldMode;
-			runSystemCommand("/usr/bin/setres.sh " + oldMode, "", nullptr);
-			SystemConf::getInstance()->set("ee_videomode", oldMode);
-			SystemConf::getInstance()->set("old_videomode", "");
-			SystemConf::getInstance()->saveSystemConf();
-			window->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
-			Scripting::fireEvent("quit", "restart");
-			quitES(QuitMode::RESTART);		
-		});
-
-		TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(window, _("Is the display set correctly ?"),
-			_("NO"), resetDisplay, _("YES"), [&, newMode] {
-				LOG(LogInfo) << "Set video to " << newMode;
-				SystemConf::getInstance()->set("ee_videomode", newMode);
-				SystemConf::getInstance()->saveSystemConf();
-			});
-		timedMsgBox->setTimedFunc(resetDisplay, 10000);
-		window->pushGui(timedMsgBox);
-	}
 }
 
 void ViewController::saveState()
@@ -150,6 +125,7 @@ void ViewController::goToStart(bool forceImmediate)
 		goToGameList(SystemData::getFirstVisibleSystem(), forceImmediate);
 	else
 		goToSystemView(SystemData::getFirstVisibleSystem());
+
 }
 
 void ViewController::ReloadAndGoToStart()
@@ -1306,6 +1282,32 @@ void ViewController::onShow()
 {
 	if (mCurrentView)
 		mCurrentView->onShow();
+
+	std::string oldMode = SystemConf::getInstance()->get("old_videomode");
+	std::string newMode = SystemConf::getInstance()->get("ee_videomode");
+
+	if (!oldMode.empty() && newMode != oldMode)
+	{
+		const std::function<void()> resetDisplay([&, window, oldMode] {
+			LOG(LogInfo) << "Reverting video to " << oldMode;
+			runSystemCommand("/usr/bin/setres.sh " + oldMode, "", nullptr);
+			SystemConf::getInstance()->set("ee_videomode", oldMode);
+			SystemConf::getInstance()->set("old_videomode", "");
+			SystemConf::getInstance()->saveSystemConf();
+			window->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
+			Scripting::fireEvent("quit", "restart");
+			quitES(QuitMode::RESTART);		
+		});
+
+		TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(window, _("Is the display set correctly ?"),
+			_("NO"), resetDisplay, _("YES"), [&, newMode] {
+				LOG(LogInfo) << "Set video to " << newMode;
+				SystemConf::getInstance()->set("ee_videomode", newMode);
+				SystemConf::getInstance()->saveSystemConf();
+			});
+		timedMsgBox->setTimedFunc(resetDisplay, 10000);
+		window->pushGui(timedMsgBox);
+	}
 }
 
 void ViewController::onScreenSaverActivate()

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -1288,25 +1288,25 @@ void ViewController::onShow()
 
 	if (!oldMode.empty() && newMode != oldMode)
 	{
-		const std::function<void()> resetDisplay([&, window, oldMode] {
+		const std::function<void()> resetDisplay([&, mWindow, oldMode] {
 			LOG(LogInfo) << "Reverting video to " << oldMode;
 			runSystemCommand("/usr/bin/setres.sh " + oldMode, "", nullptr);
 			SystemConf::getInstance()->set("ee_videomode", oldMode);
 			SystemConf::getInstance()->set("old_videomode", "");
 			SystemConf::getInstance()->saveSystemConf();
-			window->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
+			mWindow->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
 			Scripting::fireEvent("quit", "restart");
 			quitES(QuitMode::RESTART);		
 		});
 
-		TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(window, _("Is the display set correctly ?"),
+		TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(mWindow, _("Is the display set correctly ?"),
 			_("NO"), resetDisplay, _("YES"), [&, newMode] {
 				LOG(LogInfo) << "Set video to " << newMode;
 				SystemConf::getInstance()->set("ee_videomode", newMode);
 				SystemConf::getInstance()->saveSystemConf();
 			});
 		timedMsgBox->setTimedFunc(resetDisplay, 10000);
-		window->pushGui(timedMsgBox);
+		mWindow->pushGui(timedMsgBox);
 	}
 }
 

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -131,7 +131,7 @@ void ViewController::goToStart(bool forceImmediate)
 
 	if (!oldMode.empty() && newMode != oldMode)
 	{
-		const std::function<void()> resetDisplay([&, mWindow, oldMode] {
+		const std::function<void()> resetDisplay([&, oldMode] {
 			LOG(LogInfo) << "Reverting video to " << oldMode;
 			runSystemCommand("/usr/bin/setres.sh " + oldMode, "", nullptr);
 			SystemConf::getInstance()->set("ee_videomode", oldMode);

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -125,32 +125,6 @@ void ViewController::goToStart(bool forceImmediate)
 		goToGameList(SystemData::getFirstVisibleSystem(), forceImmediate);
 	else
 		goToSystemView(SystemData::getFirstVisibleSystem());
-
-	std::string oldMode = SystemConf::getInstance()->get("old_videomode");
-	std::string newMode = SystemConf::getInstance()->get("ee_videomode");
-
-	if (!oldMode.empty() && newMode != oldMode)
-	{
-		const std::function<void()> resetDisplay([&, oldMode] {
-			LOG(LogInfo) << "Reverting video to " << oldMode;
-			runSystemCommand("/usr/bin/setres.sh " + oldMode, "", nullptr);
-			SystemConf::getInstance()->set("ee_videomode", oldMode);
-			SystemConf::getInstance()->set("old_videomode", "");
-			SystemConf::getInstance()->saveSystemConf();
-			mWindow->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
-			Scripting::fireEvent("quit", "restart");
-			quitES(QuitMode::RESTART);		
-		});
-
-		TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(mWindow, _("Is the display set correctly ?"),
-			_("NO"), resetDisplay, _("YES"), [&, newMode] {
-				LOG(LogInfo) << "Set video to " << newMode;
-				SystemConf::getInstance()->set("ee_videomode", newMode);
-				SystemConf::getInstance()->saveSystemConf();
-			});
-		timedMsgBox->setTimedFunc(resetDisplay, 10000);
-		mWindow->pushGui(timedMsgBox);
-	}
 }
 
 void ViewController::ReloadAndGoToStart()
@@ -1307,6 +1281,33 @@ void ViewController::onShow()
 {
 	if (mCurrentView)
 		mCurrentView->onShow();
+		
+	std::string oldMode = SystemConf::getInstance()->get("old_videomode");
+	std::string newMode = SystemConf::getInstance()->get("ee_videomode");
+	oldMode = "720p60hz";
+	newMode = "1080p60hz";
+	if (!oldMode.empty() && newMode != oldMode)
+	{
+		const std::function<void()> resetDisplay([&, oldMode] {
+			LOG(LogInfo) << "Reverting video to " << oldMode;
+			runSystemCommand("/usr/bin/setres.sh " + oldMode, "", nullptr);
+			SystemConf::getInstance()->set("ee_videomode", oldMode);
+			SystemConf::getInstance()->set("old_videomode", "");
+			SystemConf::getInstance()->saveSystemConf();
+			mWindow->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
+			Scripting::fireEvent("quit", "restart");
+			quitES(QuitMode::RESTART);		
+		});
+
+		TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(mWindow, _("Is the display set correctly ?"),
+			_("NO"), resetDisplay, _("YES"), [&, newMode] {
+				LOG(LogInfo) << "Set video to " << newMode;
+				SystemConf::getInstance()->set("ee_videomode", newMode);
+				SystemConf::getInstance()->saveSystemConf();
+			});
+		timedMsgBox->setTimedFunc(resetDisplay, 10000);
+		mWindow->pushGui(timedMsgBox);
+	}
 }
 
 void ViewController::onScreenSaverActivate()

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -32,7 +32,6 @@
 
 #ifdef _ENABLEEMUELEC
 #include "ApiSystem.h"
-#include "platform.h"
 #endif
 
 ViewController* ViewController::sInstance = nullptr;

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -32,6 +32,7 @@
 
 #ifdef _ENABLEEMUELEC
 #include "ApiSystem.h"
+#include "platform.h"
 #endif
 
 ViewController* ViewController::sInstance = nullptr;
@@ -62,11 +63,12 @@ void ViewController::init(Window* window)
 	if (!oldMode.empty() && newMode != oldMode)
 	{
 		const std::function<void()> resetDisplay([&, window, oldMode] {
-			setDisplay(oldMode);
+			LOG(LogInfo) << "Reverting video to " << oldMode;
+			runSystemCommand("/usr/bin/setres.sh " + oldMode, "", nullptr);
 			SystemConf::getInstance()->set("old_videomode", "");		
 			window->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
 			Scripting::fireEvent("quit", "restart");
-			quitES(QuitMode::QUIT);		
+			quitES(QuitMode::RESTART);		
 		});
 
 		TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(window, _("Is the display set correctly ?"),

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -65,7 +65,9 @@ void ViewController::init(Window* window)
 		const std::function<void()> resetDisplay([&, window, oldMode] {
 			LOG(LogInfo) << "Reverting video to " << oldMode;
 			runSystemCommand("/usr/bin/setres.sh " + oldMode, "", nullptr);
-			SystemConf::getInstance()->set("old_videomode", "");		
+			SystemConf::getInstance()->set("ee_videomode", oldMode);
+			SystemConf::getInstance()->set("old_videomode", "");
+			SystemConf::getInstance()->saveSystemConf();
 			window->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
 			Scripting::fireEvent("quit", "restart");
 			quitES(QuitMode::RESTART);		

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -125,7 +125,32 @@ void ViewController::goToStart(bool forceImmediate)
 		goToGameList(SystemData::getFirstVisibleSystem(), forceImmediate);
 	else
 		goToSystemView(SystemData::getFirstVisibleSystem());
+		
+	std::string oldMode = SystemConf::getInstance()->get("old_videomode");
+	std::string newMode = SystemConf::getInstance()->get("ee_videomode");
 
+	if (!oldMode.empty() && newMode != oldMode)
+	{
+		const std::function<void()> resetDisplay([&, mWindow, oldMode] {
+			LOG(LogInfo) << "Reverting video to " << oldMode;
+			runSystemCommand("/usr/bin/setres.sh " + oldMode, "", nullptr);
+			SystemConf::getInstance()->set("ee_videomode", oldMode);
+			SystemConf::getInstance()->set("old_videomode", "");
+			SystemConf::getInstance()->saveSystemConf();
+			mWindow->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
+			Scripting::fireEvent("quit", "restart");
+			quitES(QuitMode::RESTART);		
+		});
+
+		TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(mWindow, _("Is the display set correctly ?"),
+			_("NO"), resetDisplay, _("YES"), [&, newMode] {
+				LOG(LogInfo) << "Set video to " << newMode;
+				SystemConf::getInstance()->set("ee_videomode", newMode);
+				SystemConf::getInstance()->saveSystemConf();
+			});
+		timedMsgBox->setTimedFunc(resetDisplay, 10000);
+		mWindow->pushGui(timedMsgBox);
+	}
 }
 
 void ViewController::ReloadAndGoToStart()
@@ -1282,32 +1307,6 @@ void ViewController::onShow()
 {
 	if (mCurrentView)
 		mCurrentView->onShow();
-
-	std::string oldMode = SystemConf::getInstance()->get("old_videomode");
-	std::string newMode = SystemConf::getInstance()->get("ee_videomode");
-
-	if (!oldMode.empty() && newMode != oldMode)
-	{
-		const std::function<void()> resetDisplay([&, mWindow, oldMode] {
-			LOG(LogInfo) << "Reverting video to " << oldMode;
-			runSystemCommand("/usr/bin/setres.sh " + oldMode, "", nullptr);
-			SystemConf::getInstance()->set("ee_videomode", oldMode);
-			SystemConf::getInstance()->set("old_videomode", "");
-			SystemConf::getInstance()->saveSystemConf();
-			mWindow->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
-			Scripting::fireEvent("quit", "restart");
-			quitES(QuitMode::RESTART);		
-		});
-
-		TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(mWindow, _("Is the display set correctly ?"),
-			_("NO"), resetDisplay, _("YES"), [&, newMode] {
-				LOG(LogInfo) << "Set video to " << newMode;
-				SystemConf::getInstance()->set("ee_videomode", newMode);
-				SystemConf::getInstance()->saveSystemConf();
-			});
-		timedMsgBox->setTimedFunc(resetDisplay, 10000);
-		mWindow->pushGui(timedMsgBox);
-	}
 }
 
 void ViewController::onScreenSaverActivate()

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -125,31 +125,31 @@ void ViewController::goToStart(bool forceImmediate)
 		goToGameList(SystemData::getFirstVisibleSystem(), forceImmediate);
 	else
 		goToSystemView(SystemData::getFirstVisibleSystem());
-		
+
 	std::string oldMode = SystemConf::getInstance()->get("old_videomode");
 	std::string newMode = SystemConf::getInstance()->get("ee_videomode");
 
 	if (!oldMode.empty() && newMode != oldMode)
 	{
-		const std::function<void()> resetDisplay([&, oldMode] {
+		const std::function<void()> resetDisplay([&, mWindow, oldMode] {
 			LOG(LogInfo) << "Reverting video to " << oldMode;
 			runSystemCommand("/usr/bin/setres.sh " + oldMode, "", nullptr);
 			SystemConf::getInstance()->set("ee_videomode", oldMode);
 			SystemConf::getInstance()->set("old_videomode", "");
 			SystemConf::getInstance()->saveSystemConf();
-			displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
+			mWindow->displayNotificationMessage(_U("\uF011  ") + _("DISPLAY RESET"));
 			Scripting::fireEvent("quit", "restart");
 			quitES(QuitMode::RESTART);		
 		});
 
-		TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(this, _("Is the display set correctly ?"),
+		TimedGuiMsgBox* timedMsgBox = new TimedGuiMsgBox(mWindow, _("Is the display set correctly ?"),
 			_("NO"), resetDisplay, _("YES"), [&, newMode] {
 				LOG(LogInfo) << "Set video to " << newMode;
 				SystemConf::getInstance()->set("ee_videomode", newMode);
 				SystemConf::getInstance()->saveSystemConf();
 			});
 		timedMsgBox->setTimedFunc(resetDisplay, 10000);
-		pushGui(timedMsgBox);
+		mWindow->pushGui(timedMsgBox);
 	}
 }
 

--- a/es-core/src/guis/GuiMsgBox.cpp
+++ b/es-core/src/guis/GuiMsgBox.cpp
@@ -215,3 +215,23 @@ std::vector<HelpPrompt> GuiMsgBox::getHelpPrompts()
 {
 	return mGrid.getHelpPrompts();
 }
+
+#ifdef _ENABLEEMUELEC
+void TimedGuiMsgBox::update(int deltaTime)
+{
+	GuiMsgBox::update(deltaTime);
+
+	if (mCheckTime >= 0)
+	{
+		mCheckTime += deltaTime;
+		if (mCheckTime >= mTimeoutDelay)
+		{
+			auto funcCopy = timedFunc;
+			delete this;
+
+			if(funcCopy)
+				funcCopy();
+		}
+	}
+}
+#endif

--- a/es-core/src/guis/GuiMsgBox.h
+++ b/es-core/src/guis/GuiMsgBox.h
@@ -58,4 +58,32 @@ private:
 	std::function<void()> mAcceleratorFunc;
 };
 
+#ifdef _ENABLEEMUELEC
+
+class TimedGuiMsgBox : public GuiMsgBox
+{
+private:
+	std::function<void()> timedFunc;
+	int mTimeoutDelay;
+	int mCheckTime;
+
+public:
+	TimedGuiMsgBox(Window* window, const std::string& text,
+		const std::string& name1, const std::function<void()>& func1,
+		const std::string& name2, const std::function<void()>& func2,
+		GuiMsgBoxIcon icon = ICON_AUTOMATIC):mCheckTime(-1),
+		GuiMsgBox(window, text, name1, func1, name2, func2, "", nullptr, icon) {
+	};
+
+	void update(int deltaTime) override;
+	void setTimedFunc(const std::function<void()>& func, int time)
+	{
+		mTimeoutDelay = time;
+		timedFunc = func;
+		mCheckTime = 0;
+	};
+};
+
+#endif
+
 #endif // ES_CORE_GUIS_GUI_MSG_BOX_H


### PR DESCRIPTION
- Changes to the main resolution function. Main difference is no reboot is needed when changing resolutions and it has safer measures to switch back in case the resolution output corrupts.
- Switches main resolutions then comes up with a dialog if it changed ok and option to revert resolution back.
- If the user takes more than 10 seconds to confirm resolution it switches it back to the default.
- Enables main resolution changing without having to restart ES.
- Adds a warning for native video when the EE-utils function resolutions does not return the correct resolution.

Designed to work with EE change here:
https://github.com/EmuELEC/EmuELEC/pull/901
