### PR TITLE
EE-ES resolution switch new fixes. #2

### DIFF
--- a/es-app/src/views/SystemView.cpp
+++ b/es-app/src/views/SystemView.cpp
@@ -50,18 +50,13 @@ SystemView::SystemView(Window* window) : IList<SystemViewData, SystemData*>(wind
 	mDisable = false;		
 	mLastCursor = 0;
 	mExtrasFadeOldCursor = -1;
-<<<<<<< ours
-
 	mLockCamOffsetChanges = false;
 	mLockExtraChanges = false;
 	mPressedCursor = -1;
 	mPressedPoint = Vector2i(-1, -1);
-=======
 #ifdef _ENABLEEMUELEC
-		mCheckResTime = 0;
+	mCheckResTime = 0;
 #endif
->>>>>>> theirs
-
 	setSize((float)Renderer::getScreenWidth(), (float)Renderer::getScreenHeight());
 	populate();
 }

--- a/es-app/src/views/SystemView.h
+++ b/es-app/src/views/SystemView.h
@@ -81,6 +81,11 @@ public:
 	virtual void update(int deltaTime) override;
 	virtual void render(const Transform4x4f& parentTrans) override;
 
+#ifdef _ENABLEEMUELEC
+	int mCheckResTime;
+	void checkResolutionSwitch();
+#endif
+
 	// Help
 	std::vector<HelpPrompt> getHelpPrompts() override;
 	virtual HelpStyle getHelpStyle() override;

--- a/es-core/src/guis/GuiMsgBox.cpp
+++ b/es-core/src/guis/GuiMsgBox.cpp
@@ -216,3 +216,23 @@ std::vector<HelpPrompt> GuiMsgBox::getHelpPrompts()
 {
 	return mGrid.getHelpPrompts();
 }
+
+#ifdef _ENABLEEMUELEC
+void TimedGuiMsgBox::update(int deltaTime)
+{
+	GuiMsgBox::update(deltaTime);
+
+	if (mCheckTime >= 0)
+	{
+		mCheckTime += deltaTime;
+		if (mCheckTime >= mTimeoutDelay)
+		{
+			auto funcCopy = timedFunc;
+			delete this;
+
+			if(funcCopy)
+				funcCopy();
+		}
+	}
+}
+#endif

--- a/es-core/src/guis/GuiMsgBox.h
+++ b/es-core/src/guis/GuiMsgBox.h
@@ -58,4 +58,32 @@ private:
 	std::function<void()> mAcceleratorFunc;
 };
 
+#ifdef _ENABLEEMUELEC
+
+class TimedGuiMsgBox : public GuiMsgBox
+{
+private:
+	std::function<void()> timedFunc;
+	int mTimeoutDelay;
+	int mCheckTime;
+
+public:
+	TimedGuiMsgBox(Window* window, const std::string& text,
+		const std::string& name1, const std::function<void()>& func1,
+		const std::string& name2, const std::function<void()>& func2,
+		GuiMsgBoxIcon icon = ICON_AUTOMATIC):mCheckTime(-1),
+		GuiMsgBox(window, text, name1, func1, name2, func2, "", nullptr, icon) {
+	};
+
+	void update(int deltaTime) override;
+	void setTimedFunc(const std::function<void()>& func, int time)
+	{
+		mTimeoutDelay = time;
+		timedFunc = func;
+		mCheckTime = 0;
+	};
+};
+
+#endif
+
 #endif // ES_CORE_GUIS_GUI_MSG_BOX_H


### PR DESCRIPTION
This enables resolution switching, and restarts ES and comes up with a prompt if the display is correct. In 10 seconds if no response is given or the user selects NO then the resolution will switch back to it's default. Still need to do 1 more final test to make sure my minor changes hasn't changed anything.
edit:
Also when switching resolutions ES will restart so it can re-init the renderer. There might be a more optimum way but for now a restart is the most easy and reliable.

Original code work:
https://github.com/EmuELEC/emuelec-emulationstation/pull/58
https://github.com/EmuELEC/emuelec-emulationstation/pull/57