### PR TITLE
Feature - Cloud Saves working in tandem with the Save State Manager

### DIFF
--- a/es-app/CMakeLists.txt
+++ b/es-app/CMakeLists.txt
@@ -27,6 +27,7 @@ set(ES_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/src/SaveState.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/SaveStateRepository.h
 	${CMAKE_CURRENT_SOURCE_DIR}/src/CustomFeatures.h
+	${CMAKE_CURRENT_SOURCE_DIR}/src/CloudSaves.h
 
     # GuiComponents
     ${CMAKE_CURRENT_SOURCE_DIR}/src/components/AsyncReqComponent.h
@@ -132,7 +133,8 @@ set(ES_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/RetroAchievements.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/SaveState.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/SaveStateRepository.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/src/CustomFeatures.cpp	
+	${CMAKE_CURRENT_SOURCE_DIR}/src/CustomFeatures.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/CloudSaves.cpp
 
     # GuiComponents
     ${CMAKE_CURRENT_SOURCE_DIR}/src/components/AsyncReqComponent.cpp

--- a/es-app/src/CloudSaves.cpp
+++ b/es-app/src/CloudSaves.cpp
@@ -58,6 +58,8 @@ bool CloudSaves::isSupported(FileData* game)
 		game->getEmulator(true),
 		game->getEmulator(true),
 		EmulatorFeatures::cloudsave);
+  canCloudSave = canCloudSave && 
+    SystemConf::getInstance()->get(system->getName() + ".cloudsave") == "1";
 	canCloudSave = canCloudSave && SaveStateRepository::isEnabled(game);
   return canCloudSave;
 }

--- a/es-app/src/CloudSaves.cpp
+++ b/es-app/src/CloudSaves.cpp
@@ -1,0 +1,63 @@
+#include "CloudSaves.h"
+
+#include "guis/GuiLoading.h"
+#include "guis/GuiMsgBox.h"
+#include "guis/GuiSaveState.h"
+#include "SaveStateRepository.h"
+#include "platform.h"
+
+void guiSaveStateLoad(Window* window, FileData* game)
+{
+  GuiComponent* guiComp = window->peekGui();
+  GuiSaveState* guiSaveState = dynamic_cast<GuiSaveState*>(guiComp);
+  if (guiSaveState && CloudSaves::getInstance().isSupported(game)) {
+    auto callback = [](GuiComponent* guiComp) {
+      GuiSaveState* guiSaveState = dynamic_cast<GuiSaveState*>(guiComp);
+      if (guiSaveState)
+        guiSaveState->loadGridAndCenter();
+    };
+    CloudSaves::getInstance().load(window, game, guiSaveState, callback);
+  }  
+}
+
+void CloudSaves::load(Window* window, FileData *game, GuiComponent* guiComp, const std::function<void(GuiComponent*)>& callback)
+{
+  guiComp->setVisible(false);
+	auto loading = new GuiLoading<bool>(window, _("LOADING PLEASE WAIT"),
+	[this, window, game, guiComp, callback](auto gui) {
+		std::string sysName = game->getSourceFileData()->getSystem()->getName();
+		int exitCode = runSystemCommand("ra_rclone.sh get \""+sysName+"\" \""+game->getPath()+"\"", "", nullptr);
+		if (exitCode != 0)
+			window->pushGui(new GuiMsgBox(window, _("ERROR LOADING FROM CLOUD"), _("OK")));
+    guiComp->setVisible(true);
+    callback(guiComp);
+		return true;
+	});
+	window->pushGui(loading);
+}
+
+void CloudSaves::save(Window* window, FileData* game)
+{
+	auto loading = new GuiLoading<bool>(window, _("SAVING PLEASE WAIT"),
+	[this, window, game](auto gui) {
+		std::string sysName = game->getSourceFileData()->getSystem()->getName();
+		int exitCode = runSystemCommand("ra_rclone.sh set \""+sysName+"\" \""+game->getPath()+"\"", "", nullptr);
+		if (exitCode != 0)
+			window->pushGui(new GuiMsgBox(window, _("ERROR SAVING TO CLOUD"), _("OK")));
+		else
+			window->pushGui(new GuiMsgBox(window, _("SAVED TO CLOUD"), _("OK")));
+		return true;
+	});
+	window->pushGui(loading);
+}
+
+bool CloudSaves::isSupported(FileData* game)
+{
+  SystemData* system = game->getSourceFileData()->getSystem();
+	bool canCloudSave = system->isFeatureSupported(
+		game->getEmulator(true),
+		game->getEmulator(true),
+		EmulatorFeatures::cloudsave);
+	canCloudSave = canCloudSave && SaveStateRepository::isEnabled(game);
+  return canCloudSave;
+}

--- a/es-app/src/CloudSaves.cpp
+++ b/es-app/src/CloudSaves.cpp
@@ -1,5 +1,6 @@
 #include "CloudSaves.h"
 
+#include "SystemConf.h"
 #include "guis/GuiLoading.h"
 #include "guis/GuiMsgBox.h"
 #include "guis/GuiSaveState.h"

--- a/es-app/src/CloudSaves.h
+++ b/es-app/src/CloudSaves.h
@@ -1,0 +1,30 @@
+#pragma once
+#ifndef ES_APP_SERVICES_CLOUDSAVE_SERVICE_H
+#define ES_APP_SERVICES_CLOUDSAVE_SERVICE_H
+
+#include "Window.h"
+#include "FileData.h"
+#include "GuiComponent.h"
+
+class CloudSaves
+{
+  public:
+    static CloudSaves& getInstance()
+    {
+      static CloudSaves instance;
+      return instance;
+    }
+  private:
+    CloudSaves() {}
+    CloudSaves(CloudSaves const&);
+    void operator=(CloudSaves const&);
+  public:
+    void save(Window* window, FileData* game);
+    void load(Window* window, FileData *game, GuiComponent* guiComp,
+    const std::function<void(GuiComponent*)>& callback);
+    bool isSupported(FileData* game);
+};
+
+extern void guiSaveStateLoad(Window* window, FileData* game);
+
+#endif

--- a/es-app/src/CustomFeatures.cpp
+++ b/es-app/src/CustomFeatures.cpp
@@ -57,6 +57,7 @@ EmulatorFeatures::Features EmulatorFeatures::parseFeatures(const std::string fea
 		if (trim == "nativevideo") ret = ret | EmulatorFeatures::Features::nativevideo;
 		if (trim == "joybtnremap") ret = ret | EmulatorFeatures::Features::joybtnremap;
 		if (trim == "hlebios") ret = ret | EmulatorFeatures::Features::hlebios;
+		if (trim == "cloudsave") ret = ret | EmulatorFeatures::Features::cloudsave;
 #endif
 	}
 

--- a/es-app/src/CustomFeatures.h
+++ b/es-app/src/CustomFeatures.h
@@ -94,6 +94,7 @@ public:
 		nativevideo = 1048576,
 		hlebios = 2097152,
     joybtnremap = 4194304,
+		cloudsave = 8388608,
 #endif
 		all = 0x0FFFFFFF
 	};

--- a/es-app/src/guis/GuiGameOptions.cpp
+++ b/es-app/src/guis/GuiGameOptions.cpp
@@ -28,8 +28,8 @@
 #include "SystemConf.h"
 
 #ifdef _ENABLEEMUELEC
-#include "platform.h"
 #include <regex>
+#include "platform.h"
 #endif
 
 GuiGameOptions::GuiGameOptions(Window* window, FileData* game) : GuiComponent(window),
@@ -147,18 +147,21 @@ GuiGameOptions::GuiGameOptions(Window* window, FileData* game) : GuiComponent(wi
 	{
 		mMenu.addGroup(_("GAME"));
 
+ 
 		if (SaveStateRepository::isEnabled(game))
 		{
 			mMenu.addEntry(_("SAVE STATES"), false, [window, game, this]
 			{
-				mWindow->pushGui(new GuiSaveState(mWindow, game, [this, game](SaveState state)
-				{
-					LaunchGameOptions options;
-					options.saveStateInfo = state;
-					ViewController::get()->launch(game, options);
-				}));
-
-				this->close();
+					mWindow->pushGui(new GuiSaveState(mWindow, game, [this, game](SaveState state)
+					{
+						LaunchGameOptions options;
+						options.saveStateInfo = state;
+						ViewController::get()->launch(game, options);
+					}));
+#ifdef _ENABLEEMUELEC
+					guiSaveStateLoad(mWindow, game);
+#endif
+					this->close();
 			});
 		}
 		else

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -5117,6 +5117,23 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		systemConfiguration->addWithLabel(_("INTEGER SCALING (OVERSCALE)"), integerscaleoverscale_enabled);
 		systemConfiguration->addSaveFunc([integerscaleoverscale_enabled, configName] { SystemConf::getInstance()->set(configName + ".integerscaleoverscale", integerscaleoverscale_enabled->getSelected()); });
 	}
+
+#ifdef _ENABLEEMUELEC
+	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::cloudsave))
+	{
+		auto enable_cloudsave = std::make_shared<SwitchComponent>(mWindow);
+		bool cloudSaveEnabled = SystemConf::getInstance()->get(configName + ".cloudsave") == "1";
+		enable_cloudsave->setState(cloudSaveEnabled);
+		systemConfiguration->addWithLabel(_("ENABLE CLOUD SAVE"), enable_cloudsave);
+
+		systemConfiguration->addSaveFunc([enable_cloudsave, mWindow] {
+			bool cloudSaveEnabled = enable_cloudsave->getState();
+			SystemConf::getInstance()->set(configName + ".cloudsave", cloudSaveEnabled ? "1" : "0");
+			SystemConf::getInstance()->saveSystemConf();
+		});
+	}
+#endif
+
 #ifdef _ENABLEEMUELEC
 	// bezel
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::decoration))

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -5035,6 +5035,22 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		systemConfiguration->addSaveFunc([configName, autosave_enabled] { SystemConf::getInstance()->set(configName + ".autosave", autosave_enabled->getSelected()); });
 	}
 #ifdef _ENABLEEMUELEC
+	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::cloudsave))
+	{
+		auto enable_cloudsave = std::make_shared<SwitchComponent>(mWindow);
+		bool cloudSaveEnabled = SystemConf::getInstance()->get(configName + ".cloudsave") == "1";
+		enable_cloudsave->setState(cloudSaveEnabled);
+		systemConfiguration->addWithLabel(_("ENABLE CLOUD SAVE"), enable_cloudsave);
+
+		systemConfiguration->addSaveFunc([enable_cloudsave, mWindow, configName] {
+			bool cloudSaveEnabled = enable_cloudsave->getState();
+			SystemConf::getInstance()->set(configName + ".cloudsave", cloudSaveEnabled ? "1" : "0");
+			SystemConf::getInstance()->saveSystemConf();
+		});
+	}
+#endif
+	
+#ifdef _ENABLEEMUELEC
 	// Shaders preset
 	if (ApiSystem::getInstance()->isScriptingSupported(ApiSystem::SHADERS) &&
 		systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::shaders))
@@ -5117,23 +5133,6 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		systemConfiguration->addWithLabel(_("INTEGER SCALING (OVERSCALE)"), integerscaleoverscale_enabled);
 		systemConfiguration->addSaveFunc([integerscaleoverscale_enabled, configName] { SystemConf::getInstance()->set(configName + ".integerscaleoverscale", integerscaleoverscale_enabled->getSelected()); });
 	}
-
-#ifdef _ENABLEEMUELEC
-	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::cloudsave))
-	{
-		auto enable_cloudsave = std::make_shared<SwitchComponent>(mWindow);
-		bool cloudSaveEnabled = SystemConf::getInstance()->get(configName + ".cloudsave") == "1";
-		enable_cloudsave->setState(cloudSaveEnabled);
-		systemConfiguration->addWithLabel(_("ENABLE CLOUD SAVE"), enable_cloudsave);
-
-		systemConfiguration->addSaveFunc([enable_cloudsave, mWindow, configName] {
-			bool cloudSaveEnabled = enable_cloudsave->getState();
-			SystemConf::getInstance()->set(configName + ".cloudsave", cloudSaveEnabled ? "1" : "0");
-			SystemConf::getInstance()->saveSystemConf();
-		});
-	}
-#endif
-
 #ifdef _ENABLEEMUELEC
 	// bezel
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::decoration))

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -5126,7 +5126,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		enable_cloudsave->setState(cloudSaveEnabled);
 		systemConfiguration->addWithLabel(_("ENABLE CLOUD SAVE"), enable_cloudsave);
 
-		systemConfiguration->addSaveFunc([enable_cloudsave, mWindow] {
+		systemConfiguration->addSaveFunc([enable_cloudsave, mWindow, configName] {
 			bool cloudSaveEnabled = enable_cloudsave->getState();
 			SystemConf::getInstance()->set(configName + ".cloudsave", cloudSaveEnabled ? "1" : "0");
 			SystemConf::getInstance()->saveSystemConf();

--- a/es-app/src/guis/GuiSaveState.cpp
+++ b/es-app/src/guis/GuiSaveState.cpp
@@ -207,9 +207,10 @@ bool GuiSaveState::input(InputConfig* config, Input input)
 		{
 			const SaveState& item = mGrid->getSelected();
 #ifdef _ENABLEEMUELEC
-			if (item.slot == -3)
+			if (item.slot == -3) {
 				CloudSaves::getInstance().save(mWindow, mGame);
-			return false;
+				return false;
+			}
 #endif
 			mRunCallback(item);
 		}

--- a/es-app/src/guis/GuiSaveState.cpp
+++ b/es-app/src/guis/GuiSaveState.cpp
@@ -94,8 +94,15 @@ GuiSaveState::GuiSaveState(Window* window, FileData* game, const std::function<v
 	mGrid->applyTheme(mTheme, "grid", "gamegrid", 0);
 	mGrid->setCursorChangedCallback([&](const CursorState& /*state*/) { updateHelpPrompts(); });
 
+#ifdef _ENABLEEMUELEC
+	if (!CloudSaves::getInstance().isSupported(game)) {
+		loadGrid();
+		centerWindow();
+	}
+#else
 	loadGrid();
 	centerWindow();
+#endif
 }
 
 void GuiSaveState::loadGrid()
@@ -111,6 +118,11 @@ void GuiSaveState::loadGrid()
 		std::sort(states.begin(), states.end(), [](const SaveState* file1, const SaveState* file2) { return file1->creationDate >= file2->creationDate; });
 	else
 		std::sort(states.begin(), states.end(), [](const SaveState* file1, const SaveState* file2) { return file1->slot < file2->slot; });
+
+#ifdef _ENABLEEMUELEC
+	if (CloudSaves::getInstance().isSupported(mGame))
+		mGrid->add(_("SAVE TO CLOUD"), ":/freeslot.svg", "", "", false, false, false, false, SaveState(-3));
+#endif
 
 	mGrid->add(_("START NEW GAME"), ":/freeslot.svg", "", "", false, false, false, false, SaveState(-2));
 
@@ -194,6 +206,11 @@ bool GuiSaveState::input(InputConfig* config, Input input)
 		if (mGrid->size())
 		{
 			const SaveState& item = mGrid->getSelected();
+#ifdef _ENABLEEMUELEC
+			if (item.slot == -3)
+				CloudSaves::getInstance().save(mWindow, mGame);
+			return false;
+#endif
 			mRunCallback(item);
 		}
 

--- a/es-app/src/guis/GuiSaveState.h
+++ b/es-app/src/guis/GuiSaveState.h
@@ -10,6 +10,10 @@
 #include "components/TextComponent.h"
 #include "SaveState.h"
 
+#ifdef _ENABLEEMUELEC
+	#include "CloudSaves.h"
+#endif
+
 class ThemeData;
 class FileData;
 class SaveStateRepository;
@@ -26,6 +30,12 @@ public:
 	bool hitTest(int x, int y, Transform4x4f& parentTransform, std::vector<GuiComponent*>* pResult = nullptr) override;
 	bool onMouseClick(int button, bool pressed, int x, int y);
 
+#ifdef _ENABLEEMUELEC
+	void loadGridAndCenter() {
+		loadGrid();
+		centerWindow();
+	};
+#endif
 
 protected:
 	void centerWindow();

--- a/es-app/src/views/gamelist/ISimpleGameListView.cpp
+++ b/es-app/src/views/gamelist/ISimpleGameListView.cpp
@@ -370,6 +370,9 @@ void ISimpleGameListView::showSelectedGameSaveSnapshots()
 			ViewController::get()->launch(cursor, options);
 		}
 		));
+#ifdef _ENABLEEMUELEC
+		guiSaveStateLoad(mWindow, cursor);
+#endif
 	}
 }
 
@@ -411,6 +414,9 @@ void ISimpleGameListView::launchSelectedGame()
 					ViewController::get()->launch(cursor, options);
 				}
 				));
+#ifdef _ENABLEEMUELEC
+				guiSaveStateLoad(mWindow, cursor);
+#endif
 			}
 			else
 			{


### PR DESCRIPTION
This allows the user to upload and download save states through rclone provided they have it setup. To enable the feature, the must have rclone enable and a working config for es-drive.

You need to have the following PR of EmuELEC and re-compile your build:
https://github.com/EmuELEC/EmuELEC/pull/997

In Emuelec config file you should also list the system you want the auto cloud save states activated for provided you want it to automatically occur when launching and exiting emulators.
So in for example nintendo64 it would be it's platform id = 1. So in /emuelec/configs/emuele.conf
```
n64.cloudsave = 1
```
For all of an emulator like libretro retroarch just use:
```
cloudsave = 1
```

So in /storage/.config/rclone/rclone.conf they should have a setup that looks like this which can be obtained with the command rclone config (this is a google drive example). The drive must be labelled **emuelec**.
```
[emuelec]
type = drive
client_id = [CLIENT_ID]
client_secret = [CLIENT_SECRET]
scope = drive
token = {"access_token":"[YOUR_ACCESS_TOKEN]","expiry":"[TIMSTAMP]"}
team_drive = 
auth_owner_only = true
```

Next in /storage/.config/emulationstation/es_features.cfg and in the retroarch emulators features you add "cloudsave" into it and restart EmulationStation.
Look for emulator libretro and add cloudsave to it's features.
```
<emulator name="libretro" features="ratio, smooth, shaders, pixel_perfect, decoration, latency_reduction, game_translation, nativevideo, cloudsave">
```

Provided you have set it up correctly for that emulator you should be able to modify your saves automatically in ES's Save States Manager.
