### PR TITLE
guimenu: Fixed emulation crash when the Emuec-utils script wouldn't work

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1519,20 +1519,23 @@ void GuiMenu::openSystemSettings()
 #ifdef _ENABLEEMUELEC
 	auto emuelec_timezones = std::make_shared<OptionListComponent<std::string> >(mWindow, _("TIMEZONE"), false);
 	std::string currentTimezone = SystemConf::getInstance()->get("system.timezone");
-	if (currentTimezone.empty())
-		currentTimezone = std::string(getShOutput(R"(/usr/bin/emuelec-utils current_timezone)"));
-	std::string a;
-	for(std::stringstream ss(getShOutput(R"(/usr/bin/emuelec-utils timezones)")); getline(ss, a, ','); ) {
-		emuelec_timezones->add(a, a, currentTimezone == a); // emuelec
-	}
-	s->addWithLabel(_("TIMEZONE"), emuelec_timezones);
-	s->addSaveFunc([emuelec_timezones] {
-		if (emuelec_timezones->changed()) {
-			std::string selectedTimezone = emuelec_timezones->getSelected();
-			runSystemCommand("ln -sf /usr/share/zoneinfo/" + selectedTimezone + " $(readlink /etc/localtime)", "", nullptr);
+	if (!test_shell.compare("success")) {
+		if (currentTimezone.empty())
+			currentTimezone = std::string(getShOutput(R"(/usr/bin/emuelec-utils current_timezone)"));
+		std::string a;
+		for(std::stringstream ss(getShOutput(R"(/usr/bin/emuelec-utils timezones)")); getline(ss, a, ','); ) {
+			emuelec_timezones->add(a, a, currentTimezone == a); // emuelec
 		}
-		SystemConf::getInstance()->set("system.timezone", emuelec_timezones->getSelected());
-	});
+		s->addWithLabel(_("TIMEZONE"), emuelec_timezones);
+		s->addSaveFunc([emuelec_timezones] {
+			if (emuelec_timezones->changed()) {
+				std::string selectedTimezone = emuelec_timezones->getSelected();
+				runSystemCommand("ln -sf /usr/share/zoneinfo/" + selectedTimezone + " $(readlink /etc/localtime)", "", nullptr);
+			}
+			SystemConf::getInstance()->set("system.timezone", emuelec_timezones->getSelected());
+		});
+	}
+
 #endif
 
 	// language choice


### PR DESCRIPTION
On some systems, using busybox bash may disable Emuec-utils, leading to ui bugs. Increase test fun to ensure emulation works, See: https://github.com/EmuELEC/EmuELEC/pull/1031

Signed-off-by: ZiHan Huang <zack.huangzihan@outlook.com>