### PR TITLE
EE ES hide game shortcut

### DIFF
--- a/es-app/src/guis/GuiGameOptions.h
+++ b/es-app/src/guis/GuiGameOptions.h
@@ -31,6 +31,7 @@ private:
 	static void deleteGame(FileData* file);
 
 #ifdef _ENABLEEMUELEC
+	static void hideGame(FileData* file, bool hide);
 	static void createMultidisc(FileData* file);
 #endif
 


### PR DESCRIPTION
**Description:**
Enables game options hide function shortcut.

**Purpose:**
Very handy when you want to hide set files, or useless files, or just games you want to exclude from the gamelists. You can also unhide games in options showing hidden files then in game options selecting unhide game.
