### PR TITLE
Revert "guimenu: Fixed emulation crash when the Emuec-utils script wo…

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1544,23 +1544,20 @@ void GuiMenu::openSystemSettings()
 #ifdef _ENABLEEMUELEC
 	auto emuelec_timezones = std::make_shared<OptionListComponent<std::string> >(mWindow, _("TIMEZONE"), false);
 	std::string currentTimezone = SystemConf::getInstance()->get("system.timezone");
-	if (!test_shell.compare("success")) {
-		if (currentTimezone.empty())
-			currentTimezone = std::string(getShOutput(R"(/usr/bin/emuelec-utils current_timezone)"));
-		std::string a;
-		for(std::stringstream ss(getShOutput(R"(/usr/bin/emuelec-utils timezones)")); getline(ss, a, ','); ) {
-			emuelec_timezones->add(a, a, currentTimezone == a); // emuelec
-		}
-		s->addWithLabel(_("TIMEZONE"), emuelec_timezones);
-		s->addSaveFunc([emuelec_timezones] {
-			if (emuelec_timezones->changed()) {
-				std::string selectedTimezone = emuelec_timezones->getSelected();
-				runSystemCommand("ln -sf /usr/share/zoneinfo/" + selectedTimezone + " $(readlink /etc/localtime)", "", nullptr);
-			}
-			SystemConf::getInstance()->set("system.timezone", emuelec_timezones->getSelected());
-		});
+	if (currentTimezone.empty())
+		currentTimezone = std::string(getShOutput(R"(/usr/bin/emuelec-utils current_timezone)"));
+	std::string a;
+	for(std::stringstream ss(getShOutput(R"(/usr/bin/emuelec-utils timezones)")); getline(ss, a, ','); ) {
+		emuelec_timezones->add(a, a, currentTimezone == a); // emuelec
 	}
-
+	s->addWithLabel(_("TIMEZONE"), emuelec_timezones);
+	s->addSaveFunc([emuelec_timezones] {
+		if (emuelec_timezones->changed()) {
+			std::string selectedTimezone = emuelec_timezones->getSelected();
+			runSystemCommand("ln -sf /usr/share/zoneinfo/" + selectedTimezone + " $(readlink /etc/localtime)", "", nullptr);
+		}
+		SystemConf::getInstance()->set("system.timezone", emuelec_timezones->getSelected());
+	});
 #endif
 
 	// language choice


### PR DESCRIPTION
> EmuELEC/build.EmuELEC-Amlogic-ng.aarch64-4/build/emuelec-emulationstation-98debb0da132b462ebc220941c5f930aa42661c9/es-app/src/guis/GuiMenu.cpp:1547:14: error: 'test_shell' was not declared in this scope [617/621] [FAIL] install emuelec-emulationstation:target
> 
> edit: You are missing the test_shell function implementation in this change which is breaking compilation.


This reverts commit 70977988fd9c58f623e53d50023f0226f90a02c0.

