### PR TITLE
Ee set fb and resize

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -820,16 +820,6 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	if (ee_framebuffer.empty()) {
 		ee_framebuffer = "auto";
 	}
-	std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
-	mWindow->displayNotificationMessage(_U("\uF011  ") + _(ee_borders.c_str()));
-	int borders[4] = {0, 0, 0, 0};
-	if (!ee_borders.empty()) {
-		std::vector<int> savedBorders = int_explode(ee_borders, ' ');
-		if (savedBorders.size() == 4) {
-			for(int i=0; i < 4; ++i)
-				borders[i] = savedBorders[i];
-		}
-	}
 
 	std::vector<std::string> reslist;
 		reslist.push_back("3840x2160");
@@ -886,7 +876,18 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		fbSave(name);
 	});
 
-	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions, borders] { 
+	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions] {
+		std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
+		mWindow->displayNotificationMessage(_U("\uF011  ") + _(ee_borders.c_str()));
+		int borders[4] = {0, 0, 0, 0};
+		if (!ee_borders.empty()) {
+			std::vector<int> savedBorders = int_explode(ee_borders, ' ');
+			if (savedBorders.size() == 4) {
+				for(int i=0; i < 4; ++i)
+					borders[i] = savedBorders[i];
+			}
+		}
+
 		GuiSettings* bordersConfig = new GuiSettings(mWindow, _("FRAME BORDERS"));
 		if (ee_framebuffer.empty())
 			return;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -895,51 +895,43 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		fbSave(emuelec_frame_buffer->getSelected());
 	});
 
-	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions] {
-		std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
-		int borders[4] = {0,0,0,0};
-		if (!ee_borders.empty()) {
-			std::vector<int> savedBorders = int_explode(ee_borders, ' ');
-			if (savedBorders.size() == 4) {
-				for(int i=0; i < 4; ++i)
-					borders[i] = savedBorders[i];
-			}
+	std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
+	int borders[4] = {0,0,0,0};
+	if (!ee_borders.empty()) {
+		std::vector<int> savedBorders = int_explode(ee_borders, ' ');
+		if (savedBorders.size() == 4) {
+			for(int i=0; i < 4; ++i)
+				borders[i] = savedBorders[i];
 		}
+	}
 
+	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions, &borders] {
 		GuiSettings* bordersConfig = new GuiSettings(mWindow, _("FRAME BORDERS"));
 		if (ee_framebuffer.empty())
 			return;
 
-		auto saveBorders = [mWindow, ee_videomode, borders]() {
-			std::string result = std::to_string(borders[0])+" "+
-				std::to_string(borders[1])+" "+
-				std::to_string(borders[2])+" "+
-				std::to_string(borders[3]);
-			SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);
-		};
-			
 		float width = float(dimensions[0])/2.0f;
 		float height = float(dimensions[1])/2.0f;
 
 		// borders
 		auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
 		leftborder->setValue((float)borders[0]);
-		leftborder->setOnValueChanged([&borders](const float &newVal) {
+		leftborder->setOnValueChanged([borders](const float &newVal) {
 			borders[0] = (int)Math::round(newVal);
 		});
 		auto topborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
 		topborder->setValue((float)borders[1]);
-		topborder->setOnValueChanged([&borders](const float &newVal) {
+		topborder->setOnValueChanged([borders](const float &newVal) {
 			borders[1] = (int)Math::round(newVal);
 		});
 		auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
 		rightborder->setValue((float)borders[2]);
-		rightborder->setOnValueChanged([&borders](const float &newVal) {
+		rightborder->setOnValueChanged([borders](const float &newVal) {
 			borders[2] = (int)Math::round(newVal);
 		});
 		auto bottomborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
 		bottomborder->setValue((float)borders[3]);
-		bottomborder->setOnValueChanged([&borders](const float &newVal) {
+		bottomborder->setOnValueChanged([borders](const float &newVal) {
 			borders[3] = (int)Math::round(newVal);
 		});
 
@@ -950,9 +942,13 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 		bordersConfig->addSaveFunc([mWindow, saveBorders, ee_videomode, dimensions, borders]()
 		{
-			saveBorders();
-
 			std::string result = std::to_string(borders[0])+" "+
+				std::to_string(borders[1])+" "+
+				std::to_string(borders[2])+" "+
+				std::to_string(borders[3]);
+			SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);
+
+			result = std::to_string(borders[0])+" "+
 				std::to_string(borders[1])+" "+
 				std::to_string(dimensions[0]-borders[2]-1)+" "+
 				std::to_string(dimensions[1]-borders[3]-1);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -856,9 +856,13 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 	int* ee_dimensions = getVideoModeDimensions(ee_videomode, reslist);
 
-	sScreenDimensions ee_screen;
+	static sScreenDimensions ee_screen;
 	ee_screen.width = ee_dimensions[0];
 	ee_screen.height = ee_dimensions[1];
+
+	char buffer[100];
+	sprintf(buffer, "dim: %d %d", ee_screen.width, ee_screen.height);
+	mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
 	/*std::shared_ptr<int> ee_dimensions (new int [2], [](int* d){
 		 delete [] d;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -146,7 +146,7 @@ static std::string toupper(std::string s)
 
 int* getVideoModeDimensions(std::string videomode, std::vector<std::string> reslist) 
 {
-	int screen[2] = {0, 0};
+	static int screen[2] = {0, 0};
 
 	if (videomode == "480cvbs")
 	{

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -771,9 +771,10 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		if (ee_framebuffer.empty())
 			ee_framebuffer = "auto";
 			
-		emuelec_frame_buffer->add("auto", "auto", ee_framebuffer == *it); }			
+		emuelec_frame_buffer->add("auto", "auto", ee_framebuffer == *it);
 		for (auto it = framebuffer.cbegin(); it != framebuffer.cend(); it++) {
-			emuelec_frame_buffer->add(*it, *it, ee_framebuffer == *it); }
+			emuelec_frame_buffer->add(*it, *it, ee_framebuffer == *it); 
+		}
 		dangerZone->addWithLabel(_("FRAME BUFFER"), emuelec_frame_buffer);
 	   	
 		dangerZone->addSaveFunc([mWindow, emuelec_frame_buffer, ee_videomode] {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -780,12 +780,11 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		dangerZone->addSaveFunc([mWindow, emuelec_frame_buffer, ee_videomode] {
 			if (emuelec_frame_buffer->changed()) {
 				std::string selectedFB = emuelec_frame_buffer->getSelected();
-				int pos = selectedFB.find('x');
-				int screenWidth = atoi(selectedFB.substr(0, pos).c_str());
-				int screenHeight = atoi(selectedFB.substr(pos+1).c_str());
+				//int pos = selectedFB.find('x');
+				//int screenWidth = atoi(selectedFB.substr(0, pos).c_str());
+				//int screenHeight = atoi(selectedFB.substr(pos+1).c_str());
 
-				std::string ee_videomode = SystemConf::getInstance()->get("ee_videomode");
-				SystemConf::getInstance()->set(ee_videomode+".ee_framebuffer", screenWidth+" "+screenHeight);
+				SystemConf::getInstance()->set(ee_videomode+".ee_framebuffer", selectedFB);
 				mWindow->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
 			}
 		});

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -886,12 +886,12 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		fbSave(name);
 	});
 
-	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions, &borders] { 
+	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions, borders] { 
 		GuiSettings* bordersConfig = new GuiSettings(mWindow, _("FRAME BORDERS"));
 		if (ee_framebuffer.empty())
 			return;
 
-		auto saveBorders = [mWindow, ee_videomode, &borders]() {
+		auto saveBorders = [mWindow, ee_videomode, borders]() {
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _("saveBorders"));
 			std::string result = std::to_string(borders[0])+" "+
 				std::to_string(borders[1])+" "+

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -144,9 +144,9 @@ static std::string toupper(std::string s)
 	return s;
 }
 
-static int* getVideoModeDimensions(std::string videomode, std::vector<std::string> reslist) 
+int* getVideoModeDimensions(std::string videomode, std::vector<std::string> reslist) 
 {
-	static int screen[2] = {0, 0};
+	int screen[2] = {0, 0};
 
 	if (videomode == "480cvbs")
 	{

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -883,8 +883,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				return;
 			}
 			
-			int width = *ee_dimensions[0];
-			int height = *ee_dimensions[1];
+			int width = ee_dimensions.get()[0];
+			int height = ee_dimensions.get()[1];
 
 			std::string result = "0 0 "+
 				std::to_string(width-1)+" "+
@@ -897,7 +897,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	emuelec_frame_buffer->setSelectedChangedCallback([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, ee_dimensions](std::string name)
 	{
 		char buffer[100];
-		sprintf(buffer, "dim: %.0f %.0f", *ee_dimensions[0], *ee_dimensions[1]);
+		sprintf(buffer, "dim: %.0f %.0f", ee_dimensions.get()[0], ee_dimensions.get()[1]);
 		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 				
 		fbSave(emuelec_frame_buffer->getSelected());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -790,61 +790,60 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			}
 		});
 
-		if (!ee_framebuffer.empty() && ee_framebuffer != "auto") {
-			dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, screenWidth, screenHeight] { 
-				GuiSettings* bordersConfig = new GuiSettings(mWindow, _("FRAME BORDERS"));
-				if (ee_framebuffer.empty())
-					return;
+		dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, screenWidth, screenHeight] { 
+			GuiSettings* bordersConfig = new GuiSettings(mWindow, _("FRAME BORDERS"));
+			if (ee_framebuffer.empty())
+				return;
 
 
-				std::vector<int> borders;
-		    std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
-		    std::stringstream data(ee_borders);
-		    std::string line;
-		    while(std::getline(data,line,' '))
-		    {
-		        borders.push_back(atoi(line.c_str()));
-		    }
+			std::vector<int> borders;
+	    std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
+	    std::stringstream data(ee_borders);
+	    std::string line;
+	    while(std::getline(data,line,' '))
+	    {
+	        borders.push_back(atoi(line.c_str()));
+	    }
 
-				// borders
-				auto leftborder = std::make_shared<SliderComponent>(mWindow, 0, int(screenWidth)/2, 1, "px");
-				leftborder->setValue((int)borders[0]);
-				leftborder->setOnValueChanged([&borders](const float &newVal) {
-					borders[0] = (int)Math::round(newVal);
-				});
-				auto topborder = std::make_shared<SliderComponent>(mWindow, 0, int(screenHeight)/2, 1, "px");
-				topborder->setValue((int)borders[1]);
-				topborder->setOnValueChanged([&borders](const float &newVal) {
-					borders[1] = (int)Math::round(newVal);
-				});
-				auto rightborder = std::make_shared<SliderComponent>(mWindow, int(screenWidth)-1, int(screenWidth)/2, -1, "px");
-				rightborder->setValue((int)borders[2]);
-				rightborder->setOnValueChanged([&borders](const float &newVal) {
-					borders[2] = (int)Math::round(newVal);
-				});
-				auto bottomborder = std::make_shared<SliderComponent>(mWindow, int(screenHeight)-1, int(screenHeight)/2, -1, "px");
-				bottomborder->setValue((int)borders[3]);
-				bottomborder->setOnValueChanged([&borders](const float &newVal) {
-					borders[3] = (int)Math::round(newVal);
-				});
-
-				bordersConfig->addWithLabel(_("LEFT BORDER"), leftborder);
-				bordersConfig->addWithLabel(_("TOP BORDER"), topborder);
-				bordersConfig->addWithLabel(_("RIGHT BORDER"), rightborder);
-				bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
-
-				bordersConfig->addSaveFunc([ee_videomode, borders]
-				{
-					std::string result = std::to_string(borders[0])+" "+
-						std::to_string(borders[1])+" "+
-						std::to_string(borders[2])+" "+
-						std::to_string(borders[3]);
-					SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);
-					runSystemCommand("ee_set_borders "+result, "", nullptr);
-				});
-				mWindow->pushGui(bordersConfig);
+			// borders
+			auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenWidth)/2.0f, 1.0f, "px");
+			leftborder->setValue((int)borders[0]);
+			leftborder->setOnValueChanged([&borders](const float &newVal) {
+				borders[0] = (int)Math::round(newVal);
 			});
-		}
+			auto topborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenHeight)/2.0f, 1.0f, "px");
+			topborder->setValue((int)borders[1]);
+			topborder->setOnValueChanged([&borders](const float &newVal) {
+				borders[1] = (int)Math::round(newVal);
+			});
+			auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenWidth)/2.0f, 1.0f, "px");
+			rightborder->setValue((int)borders[2]);
+			rightborder->setOnValueChanged([&borders](const float &newVal) {
+				borders[2] = screenWidth-1-(int)Math::round(newVal);
+			});
+			auto bottomborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenHeight)/2.0f, 1.0f, "px");
+			bottomborder->setValue((int)borders[3]);
+			bottomborder->setOnValueChanged([&borders](const float &newVal) {
+				borders[3] = (int)Math::round(newVal);
+			});
+
+			bordersConfig->addWithLabel(_("LEFT BORDER"), leftborder);
+			bordersConfig->addWithLabel(_("TOP BORDER"), topborder);
+			bordersConfig->addWithLabel(_("RIGHT BORDER"), rightborder);
+			bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
+
+			bordersConfig->addSaveFunc([ee_videomode, borders]
+			{
+				std::string result = std::to_string(borders[0])+" "+
+					std::to_string(borders[1])+" "+
+					std::to_string(borders[2])+" "+
+					std::to_string(borders[3]);
+				SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);
+				runSystemCommand("ee_set_borders "+result, "", nullptr);
+			});
+			mWindow->pushGui(bordersConfig);
+		});
+
 #endif
 
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -749,6 +749,16 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	std::string ee_videomode = SystemConf::getInstance()->get("ee_videomode");
 	std::string ee_framebuffer = SystemConf::getInstance()->get(ee_videomode+".ee_framebuffer");
 
+	int pos;
+	int screenWidth;
+	int screenHeight;
+
+	if (!ee_framebuffer.empty()) {
+		pos = ee_framebuffer.find('x');
+		screenWidth = atoi(ee_framebuffer.substr(0, pos).c_str());
+		screenHeight = atoi(ee_framebuffer.substr(pos+1).c_str());
+	}
+
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
         std::vector<std::string> framebuffer;
 		framebuffer.push_back("auto");
@@ -767,12 +777,12 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			emuelec_frame_buffer->add(*it, *it, ee_framebuffer == *it); }
 		dangerZone->addWithLabel(_("FRAME BUFFER"), emuelec_frame_buffer);
 	   	
-		dangerZone->addSaveFunc([mWindow, emuelec_frame_buffer, ee_videomode] {
+		dangerZone->addSaveFunc([mWindow, emuelec_frame_buffer, ee_videomode, screenWidth, screenHeight] {
 			if (emuelec_frame_buffer->changed()) {
 				std::string selectedFB = emuelec_frame_buffer->getSelected();
 				int pos = selectedFB.find('x');
-				int screenWidth = atoi(selectedFB.substr(0, pos));
-				int screenHeight = atoi(selectedFB.substr(pos+1));
+				screenWidth = atoi(selectedFB.substr(0, pos).c_str());
+				screenHeight = atoi(selectedFB.substr(pos+1).c_str());
 
 				std::string ee_videomode = SystemConf::getInstance()->get("ee_videomode");
 				SystemConf::getInstance()->set(ee_videomode+".ee_framebuffer", screenWidth+" "+screenHeight);
@@ -781,14 +791,11 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		});
 
 		if (!ee_framebuffer.empty() && ee_framebuffer != "auto") {
-			dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer] { 
+			dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, screenWidth, screenHeight] { 
 				GuiSettings* bordersConfig = new GuiSettings(mWindow, _("FRAME BORDERS"));
 				if (ee_framebuffer.empty())
 					return;
 
-				int pos = ee_framebuffer.find('x');
-				int screenWidth = atoi(ee_framebuffer.substr(0, pos));
-				int screenHeight = atoi(ee_framebuffer.substr(pos+1));
 
 				std::vector<std::string> borders;
 		    std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
@@ -824,7 +831,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				bordersConfig->addWithLabel(_("LEFT BORDER"), leftborder);
 				bordersConfig->addWithLabel(_("TOP BORDER"), topborder);
 				bordersConfig->addWithLabel(_("RIGHT BORDER"), rightborder);
-				bordersConfig->addWithLabel(_("BOTTOM BORDER"), botttomborder);
+				bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
 
 				bordersConfig->addSaveFunc([ee_videomode, borders]
 				{

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -830,6 +830,9 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 #ifdef _ENABLEEMUELEC
 	std::string ee_videomode = SystemConf::getInstance()->get("ee_videomode");
+	if (Utils::FileSystem::exists("/storage/.config/EE_VIDEO_MODE")
+		ee_videomode = getShOutput(R"(cat /storage/.config/EE_VIDEO_MODE)");
+
 	std::string ee_framebuffer = SystemConf::getInstance()->get(ee_videomode+".ee_framebuffer");
 	if (ee_framebuffer.empty()) {
 		ee_framebuffer = "auto";

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -144,9 +144,9 @@ static std::string toupper(std::string s)
 	return s;
 }
 
-std::array<int,2> getVideoModeDimensions(std::string videomode, std::vector<std::string> reslist) 
+int* getVideoModeDimensions(std::string videomode, std::vector<std::string> reslist) 
 {
-	std::array<int,2> screen;
+	static int[2] screen();
 
 	if (videomode == "480cvbs")
 	{
@@ -854,13 +854,13 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		reslist.push_back("800 600");
 		reslist.push_back("640 480");
 
-	std::array<int,2> dimensions = getVideoModeDimensions(ee_videomode, reslist);
+	int* ee_dimensions = getVideoModeDimensions(ee_videomode, reslist);
 
-	std::shared_ptr<int> ee_dimensions (new int [2], [](int* d){
+	/*std::shared_ptr<int> ee_dimensions (new int [2], [](int* d){
 		 delete [] d;
 	});
 	ee_dimensions.get()[0] = dimensions[0];
-	ee_dimensions.get()[1] = dimensions[1];
+	ee_dimensions.get()[1] = dimensions[1];*/
 	
 	
 	//char buffer[100];
@@ -890,8 +890,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				return;
 			}
 			
-			int width = ee_dimensions.get()[0];
-			int height = ee_dimensions.get()[1];
+			int width = ee_dimensions[0];
+			int height = ee_dimensions[1];
 
 			std::string result = "0 0 "+
 				std::to_string(width-1)+" "+
@@ -904,7 +904,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	emuelec_frame_buffer->setSelectedChangedCallback([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, ee_dimensions](std::string name)
 	{
 		char buffer[100];
-		sprintf(buffer, "dim: %d %d", ee_dimensions.get()[0], ee_dimensions.get()[1]);
+		sprintf(buffer, "dim: %d %d", ee_dimensions[0], ee_dimensions[1]);
 		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 				
 		fbSave(emuelec_frame_buffer->getSelected());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -921,8 +921,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		if (ee_framebuffer.empty())
 			return;
 
-		float width = float(dimensions[0])/2.0f;
-		float height = float(dimensions[1])/2.0f;
+		float width = float(ee_dimensions[0])/2.0f;
+		float height = float(ee_dimensions[1])/2.0f;
 
 		// borders
 		auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -797,7 +797,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 			int[] borders = {0,0,0,0};
 	    std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
-			if (!ee_borders.empty())
+			if (!ee_borders.empty()) {
 		    std::stringstream data(ee_borders);
 		    std::string line;
 				int i=0;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -834,7 +834,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		reslist.push_back("640x480");
 
 	int* dimensions = getVideoModeDimensions(ee_videomode, reslist);
-	mWindow->displayNotificationMessage(_U("\uF011  ") + dimensions[0] + " " + dimensions[1]);
+	mWindow->displayNotificationMessage(_U("\uF011  ") + std::to_string(dimensions[0]) + " " + std::to_string(dimensions[1]));
 
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -809,23 +809,23 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				// borders
 				auto leftborder = std::make_shared<SliderComponent>(mWindow, 0, int(screenWidth)/2, 1, "px");
 				leftborder->setValue((int)borders[0]);
-				leftborder->setOnValueChanged([borders](int &newVal) {
-					borders[0] = newVal;
+				leftborder->setOnValueChanged([borders](const float &newVal) {
+					borders[0] = (int)Math::round(newVal);
 				});
 				auto topborder = std::make_shared<SliderComponent>(mWindow, 0, int(screenHeight)/2, 1, "px");
 				topborder->setValue((int)borders[1]);
-				topborder->setOnValueChanged([borders](int &newVal) {
-					borders[1] = newVal;
+				topborder->setOnValueChanged([borders](const float &newVal) {
+					borders[1] = (int)Math::round(newVal);
 				});
 				auto rightborder = std::make_shared<SliderComponent>(mWindow, int(screenWidth)-1, int(screenWidth)/2, -1, "px");
 				rightborder->setValue((int)borders[2]);
-				rightborder->setOnValueChanged([borders](int &newVal) {
-					borders[2] = newVal;
+				rightborder->setOnValueChanged([borders](const float &newVal) {
+					borders[2] = (int)Math::round(newVal);
 				});
 				auto bottomborder = std::make_shared<SliderComponent>(mWindow, int(screenHeight)-1, int(screenHeight)/2, -1, "px");
 				bottomborder->setValue((int)borders[3]);
-				bottomborder->setOnValueChanged([borders](int &newVal) {
-					borders[3] = newVal;
+				bottomborder->setOnValueChanged([borders](const float &newVal) {
+					borders[3] = (int)Math::round(newVal);
 				});
 
 				bordersConfig->addWithLabel(_("LEFT BORDER"), leftborder);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -895,21 +895,23 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		fbSave(emuelec_frame_buffer->getSelected());
 	});
 
-
-
-	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions] {
-		std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
-		float _borders[4] = {0, 0, 0, 0};
-		char buffer[100];
-		sprintf(buffer, "%.0f %.0f %.0f %.0f", _borders[0], _borders[1], _borders[2], _borders[3]);
-		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
-		if (!ee_borders.empty()) {
-			std::vector<int> savedBorders = int_explode(ee_borders, ' ');
-			if (savedBorders.size() == 4) {
-				for(int i=0; i < 4; ++i)
-					_borders[i] = (float) savedBorders[i];
-			}
+	std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
+	float _borders[4] = {0, 0, 0, 0};
+	char buffer[100];
+	sprintf(buffer, "%.0f %.0f %.0f %.0f", _borders[0], _borders[1], _borders[2], _borders[3]);
+	mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
+	if (!ee_borders.empty()) {
+		std::vector<int> savedBorders = int_explode(ee_borders, ' ');
+		if (savedBorders.size() == 4) {
+			for(int i=0; i < 4; ++i)
+				_borders[i] = (float) savedBorders[i];
 		}
+	}
+	sprintf(buffer, "%.0f %.0f %.0f %.0f", _borders[0], _borders[1], _borders[2], _borders[3]);
+	mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
+
+	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions, _borders] {
+		char buffer[100];
 		sprintf(buffer, "%.0f %.0f %.0f %.0f", _borders[0], _borders[1], _borders[2], _borders[3]);
 		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
@@ -947,8 +949,9 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		bordersConfig->addWithLabel(_("TOP BORDER"), topborder);
 		bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
 
-		bordersConfig->addSaveFunc([ee_videomode, dimensions, &_borders]()
+		bordersConfig->addSaveFunc([mWindow, ee_videomode, dimensions, &_borders]()
 		{
+			char buffer[100];
 			sprintf(buffer, "%.0f %.0f %.0f %.0f", _borders[0], _borders[1], _borders[2], _borders[3]);
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 			

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -936,7 +936,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			return;
 
 		float width = (float)ee_screen.width;
-		float height = (float)ee_screen.height);
+		float height = (float)ee_screen.height;
 
 		// borders
 		auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -854,7 +854,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		reslist.push_back("800 600");
 		reslist.push_back("640 480");
 
-	int* ee_dimensions = getVideoModeDimensions(ee_videomode, reslist);
+	auto ee_dimensions = std::make_shared<int*>(getVideoModeDimensions(ee_videomode, reslist));
 
 	char buffer[100];
 	sprintf(buffer, "dimensions: %.0f %.0f", ee_dimensions[0], ee_dimensions[1]);
@@ -907,7 +907,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	//sprintf(buffer, "border: %.0f %.0f %.0f %.0f", ee_borders[0], ee_borders[1], ee_borders[2], ee_borders[3]);
 	//mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
-	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, ee_dimensions] {
+	/*dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, ee_dimensions] {
 		std::string str_ee_offsets = SystemConf::getInstance()->get(ee_videomode+".ee_offsets");	
 		static float ee_borders[4] = {0.0,0.0,0.0,0.0};
 		//memset(ee_borders, 0, 4*sizeof(*ee_borders));
@@ -976,12 +976,6 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			sprintf(buffer, "dim: %.0f %.0f", ee_dimensions[0], ee_dimensions[1]);
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 			
-			/*std::string result = std::to_string((int)borders[0])+" "+
-				std::to_string((int)borders[1])+" "+
-				std::to_string((int)borders[2])+" "+
-				std::to_string((int)borders[3]);
-			SystemConf::getInstance()->set(ee_videomode+".eeborders", result);*/
-
 			std::string result = std::to_string((int)borders[0])+" "+
 				std::to_string((int)borders[1])+" "+
 				std::to_string(ee_dimensions[0]-((int)borders[2])-1)+" "+
@@ -992,7 +986,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			//delete [] borders;
 		});
 
-		mWindow->pushGui(bordersConfig);
+		mWindow->pushGui(bordersConfig);*/
 	});
 
 #endif

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -858,7 +858,6 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		reslist.push_back("640x480");
 
 	int* dimensions = getVideoModeDimensions(ee_videomode, reslist);
-	//mWindow->displayNotificationMessage(_U("\uF011  ") + std::to_string(dimensions[0]) + " " + std::to_string(dimensions[1]));
 
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
 
@@ -883,11 +882,6 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				return;
 			}
 			
-			//std::string ee_offsets = SystemConf::getInstance()->get(ee_videomode+".ee_offsets");
-
-			//int pos = selectedFB.find(' ');
-			//int width = atoi(selectedFB.substr(0, pos).c_str());
-			//int height = atoi(selectedFB.substr(pos+1).c_str());
 			int width = dimensions[0];
 			int height = dimensions[1];
 
@@ -906,7 +900,6 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions] {
 		std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
-		//mWindow->displayNotificationMessage(_U("\uF011  ") + _(ee_borders.c_str()));
 		static int borders[4] = {0, 0, 0, 0};
 		if (!ee_borders.empty()) {
 			std::vector<int> savedBorders = int_explode(ee_borders, ' ');
@@ -921,7 +914,6 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			return;
 
 		auto saveBorders = [mWindow, ee_videomode, borders]() {
-			//mWindow->displayNotificationMessage(_U("\uF011  ") + _("saveBorders"));
 			std::string result = std::to_string(borders[0])+" "+
 				std::to_string(borders[1])+" "+
 				std::to_string(borders[2])+" "+
@@ -955,21 +947,13 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		});
 
 		bordersConfig->addWithLabel(_("LEFT BORDER"), leftborder);
-		bordersConfig->addWithLabel(_("TOP BORDER"), topborder);
 		bordersConfig->addWithLabel(_("RIGHT BORDER"), rightborder);
+		bordersConfig->addWithLabel(_("TOP BORDER"), topborder);
 		bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
 
 		bordersConfig->addSaveFunc([mWindow, saveBorders, ee_videomode, dimensions, borders]()
 		{
-			//mWindow->displayNotificationMessage(_U("\uF011  ") + _("bordersConfig->addSaveFunc"));
-
 			saveBorders();
-
-			/*if (borders[0] == 0 && borders[1] == 0 && borders[2] == 0 && borders[3] == 0)
-			{
-				SystemConf::getInstance()->set(ee_videomode+".ee_offsets", "");
-				return;
-			}*/
 
 			std::string result = std::to_string(borders[0])+" "+
 				std::to_string(borders[1])+" "+

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -892,8 +892,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		if (ee_framebuffer.empty())
 			return;
 
-		auto saveBorders = [mWindow, ee_videomode, borders]() {
-			mWindow->displayNotificationMessage(_U("\uF011  ") + _("saveBorders"));
+		auto saveBorders = [mWindow, ee_videomode, &borders]() {
+			//mWindow->displayNotificationMessage(_U("\uF011  ") + _("saveBorders"));
 			std::string result = std::to_string(borders[0])+" "+
 				std::to_string(borders[1])+" "+
 				std::to_string(borders[2])+" "+
@@ -935,7 +935,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		bordersConfig->addWithLabel(_("RIGHT BORDER"), rightborder);
 		bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
 
-		bordersConfig->addSaveFunc([mWindow, ee_videomode, dimensions, borders]()
+		bordersConfig->addSaveFunc([mWindow, ee_videomode, dimensions, &borders]()
 		{
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _("bordersConfig->addSaveFunc"));
 			bool hasBorder = false;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -857,7 +857,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	auto ee_dimensions = std::make_shared<int*>(getVideoModeDimensions(ee_videomode, reslist));
 
 	char buffer[100];
-	sprintf(buffer, "dimensions: %.0f %.0f", ee_dimensions.get()[0], ee_dimensions.get()[1]);
+	sprintf(buffer, "dimensions: %d %d", *ee_dimensions.get()[0], *ee_dimensions.get()[1]);
 	mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
@@ -883,8 +883,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				return;
 			}
 			
-			int width = ee_dimensions.get()[0];
-			int height = ee_dimensions.get()[1];
+			int width = *ee_dimensions.get()[0];
+			int height = *ee_dimensions.get()[1];
 
 			std::string result = "0 0 "+
 				std::to_string(width-1)+" "+
@@ -897,7 +897,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	emuelec_frame_buffer->setSelectedChangedCallback([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, ee_dimensions](std::string name)
 	{
 		char buffer[100];
-		sprintf(buffer, "dim: %.0f %.0f", ee_dimensions.get()[0], ee_dimensions.get()[1]);
+		sprintf(buffer, "dim: %.0f %.0f", *ee_dimensions.get()[0], *ee_dimensions.get()[1]);
 		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 				
 		fbSave(emuelec_frame_buffer->getSelected());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -771,7 +771,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		if (ee_framebuffer.empty())
 			ee_framebuffer = "auto";
 
-		emuelec_frame_buffer->add("auto", "auto", ee_framebuffer == *it);
+		emuelec_frame_buffer->add("auto", "auto", ee_framebuffer == "auto");
 		for (auto it = framebuffer.cbegin(); it != framebuffer.cend(); it++) {
 			emuelec_frame_buffer->add(*it, *it, ee_framebuffer == *it); 
 		}
@@ -836,12 +836,12 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			bordersConfig->addWithLabel(_("RIGHT BORDER"), rightborder);
 			bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
 
-			bordersConfig->addSaveFunc([ee_videomode, borders, ScreenWidth, ScreenHeight]
+			bordersConfig->addSaveFunc([ee_videomode, borders, screenWidth, screenHeight]
 			{
 				std::string result = std::to_string(borders[0])+" "+
 					std::to_string(borders[1])+" "+
-					std::to_string(ScreenWidth-borders[2]-1)+" "+
-					std::to_string(ScreenHeight-borders[3]-1);
+					std::to_string(screenWidth-borders[2]-1)+" "+
+					std::to_string(screenHeight-borders[3]-1);
 				SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);
 				//runSystemCommand("ee_set_borders "+result, "", nullptr);
 			});

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -809,22 +809,22 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				// borders
 				auto leftborder = std::make_shared<SliderComponent>(mWindow, 0, int(screenWidth)/2, 1, "px");
 				leftborder->setValue((int)borders[0]);
-				leftborder->setOnValueChanged([borders](const int &newVal) {
+				leftborder->setOnValueChanged([borders](int &newVal) {
 					borders[0] = newVal;
 				});
 				auto topborder = std::make_shared<SliderComponent>(mWindow, 0, int(screenHeight)/2, 1, "px");
 				topborder->setValue((int)borders[1]);
-				topborder->setOnValueChanged([borders](const int &newVal) {
+				topborder->setOnValueChanged([borders](int &newVal) {
 					borders[1] = newVal;
 				});
 				auto rightborder = std::make_shared<SliderComponent>(mWindow, int(screenWidth)-1, int(screenWidth)/2, -1, "px");
 				rightborder->setValue((int)borders[2]);
-				rightborder->setOnValueChanged([borders](const int &newVal) {
+				rightborder->setOnValueChanged([borders](int &newVal) {
 					borders[2] = newVal;
 				});
 				auto bottomborder = std::make_shared<SliderComponent>(mWindow, int(screenHeight)-1, int(screenHeight)/2, -1, "px");
 				bottomborder->setValue((int)borders[3]);
-				bottomborder->setOnValueChanged([borders](const int &newVal) {
+				bottomborder->setOnValueChanged([borders](int &newVal) {
 					borders[3] = newVal;
 				});
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -146,7 +146,7 @@ static std::string toupper(std::string s)
 
 int* getVideoModeDimensions(std::string videomode, std::vector<std::string> reslist) 
 {
-	static int[2] screen;
+	static int screen[2]();
 
 	if (videomode == "480cvbs")
 	{

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -883,7 +883,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				return;
 			}
 			
-			std::string ee_offsets = SystemConf::getInstance()->get(ee_videomode+".ee_offsets");
+			//std::string ee_offsets = SystemConf::getInstance()->get(ee_videomode+".ee_offsets");
 
 			//int pos = selectedFB.find(' ');
 			//int width = atoi(selectedFB.substr(0, pos).c_str());
@@ -965,11 +965,11 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 			saveBorders();
 
-			if (borders[0] == 0 && borders[1] == 0 && borders[2] == 0 && borders[3] == 0)
+			/*if (borders[0] == 0 && borders[1] == 0 && borders[2] == 0 && borders[3] == 0)
 			{
 				SystemConf::getInstance()->set(ee_videomode+".ee_offsets", "");
 				return;
-			}
+			}*/
 
 			std::string result = std::to_string(borders[0])+" "+
 				std::to_string(borders[1])+" "+

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -114,7 +114,7 @@
 
 static std::vector<std::string> explode(std::string sData, char delimeter=',')
 {
-	std::vector<std::string> arr;	
+	static std::vector<std::string> arr;	
 	std::stringstream ssData(sData);
 	std::string datum;
 	while(std::getline(ssData, datum, delimeter))
@@ -126,7 +126,7 @@ static std::vector<std::string> explode(std::string sData, char delimeter=',')
 
 static std::vector<int> int_explode(std::string sData, char delimeter=',')
 {
-	std::vector<int> arr;	
+	static std::vector<int> arr;	
 	std::stringstream ssData(sData);
 	std::string datum;
 	while(std::getline(ssData, datum, delimeter))

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -892,7 +892,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		if (ee_framebuffer.empty())
 			return;
 
-		auto saveBorders = [mWindow, ee_videomode](int[] b) {
+		auto saveBorders = [mWindow, ee_videomode](int b[]) {
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _("saveBorders"));
 			std::string result = std::to_string(b[0])+" "+
 				std::to_string(b[1])+" "+

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -907,12 +907,16 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				ee_borders[i] = (float) savedBorders[i];
 		}
 	}
-	sprintf(buffer, "%.0f %.0f %.0f %.0f", ee_borders[0], ee_borders[1], ee_borders[2], ee_borders[3]);
+	char buffer[100];
+	sprintf(buffer, "border: %.0f %.0f %.0f %.0f", ee_borders[0], ee_borders[1], ee_borders[2], ee_borders[3]);
 	mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
 	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, ee_dimensions, &ee_borders] {
 		char buffer[100];
-		sprintf(buffer, "%.0f %.0f %.0f %.0f", ee_borders[0], ee_borders[1], ee_borders[2], ee_borders[3]);
+		sprintf(buffer, "border: %.0f %.0f %.0f %.0f", ee_borders[0], ee_borders[1], ee_borders[2], ee_borders[3]);
+		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
+
+		sprintf(buffer, "dimensions: %.0f %.0f", ee_dimensions[0], ee_dimensions[1]);
 		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
 		GuiSettings* bordersConfig = new GuiSettings(mWindow, _("FRAME BORDERS"));
@@ -952,13 +956,16 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		bordersConfig->addSaveFunc([mWindow, ee_videomode, ee_dimensions]()
 		{
 			float borders[4] = {0.0,0.0,0.0,0.0};
-			border[0] = leftborder->getValue();
-			border[1] = topborder->getValue();
-			border[2] = rightborder->getValue();
-			border[3] = bottomborder->getValue();
+			borders[0] = leftborder->getValue();
+			borders[1] = topborder->getValue();
+			borders[2] = rightborder->getValue();
+			borders[3] = bottomborder->getValue();
 
 			char buffer[100];
-			sprintf(buffer, "%.0f %.0f %.0f %.0f", borders[0], borders[1], borders[2], borders[3]);
+			sprintf(buffer, "border: %.0f %.0f %.0f %.0f", borders[0], borders[1], borders[2], borders[3]);
+			mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
+
+			sprintf(buffer, "dim: %.0f %.0f", ee_dimensions[0], ee_dimensions[1]);
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 			
 			/*std::string result = std::to_string((int)borders[0])+" "+

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -114,7 +114,7 @@
 
 static std::vector<std::string> explode(std::string sData, char delimeter=',')
 {
-	static std::vector<std::string> arr;	
+	std::vector<std::string> arr;	
 	std::stringstream ssData(sData);
 	std::string datum;
 	while(std::getline(ssData, datum, delimeter))
@@ -126,7 +126,7 @@ static std::vector<std::string> explode(std::string sData, char delimeter=',')
 
 static std::vector<int> int_explode(std::string sData, char delimeter=',')
 {
-	static std::vector<int> arr;	
+	std::vector<int> arr;	
 	std::stringstream ssData(sData);
 	std::string datum;
 	while(std::getline(ssData, datum, delimeter))

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -906,13 +906,12 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		runSystemCommand("ee_set_borders "+result, "", nullptr);			
 	});
 
-	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions] { 
+	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions, borders] { 
 		GuiSettings* bordersConfig = new GuiSettings(mWindow, _("FRAME BORDERS"));
 		if (ee_framebuffer.empty())
 			return;
 
-
-		auto saveBorders = [ee_videomode,dimensions,borders]() {
+		auto saveBorders = [ee_videomode, dimensions, borders]() {
 			std::string result = std::to_string(borders[0])+" "+
 				std::to_string(borders[1])+" "+
 				std::to_string(borders[2])+" "+

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -956,7 +956,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			//ee_borders[2] = Math::round(newVal);
 		});
 		auto bottomborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
-		bottomborder->setValue(ee_borders.top-ee_dimensions.height+1);
+		bottomborder->setValue(ee_borders.top-ee_screen.height+1);
 		bottomborder->setOnValueChanged([](const float &newVal) {
 			//ee_borders[3] = Math::round(newVal);
 		});
@@ -966,7 +966,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		bordersConfig->addWithLabel(_("TOP BORDER"), topborder);
 		bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
 
-		bordersConfig->addSaveFunc([mWindow, ee_videomode, ee_dimensions, leftborder,rightborder,topborder,bottomborder]()
+		bordersConfig->addSaveFunc([mWindow, ee_videomode, ee_screen, leftborder,rightborder,topborder,bottomborder]()
 		{
 			float borders[4] = {0.0,0.0,0.0,0.0};
 			borders[0] = leftborder->getValue();

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -905,7 +905,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 	std::string str_ee_offsets = SystemConf::getInstance()->get(ee_videomode+".ee_offsets");
 	
-	float ee_borders[4] = {0.0,0.0,0.0,0.0};
+	static float ee_borders[4] = {0.0,0.0,0.0,0.0};
 	memset(ee_borders, 0, 4*sizeof(*ee_borders));
 
 	if (!str_ee_offsets.empty()) {
@@ -915,7 +915,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				ee_borders[i] = (float) savedBorders[i];
 		}
 	}
-	char buffer[100];
+	buffer[100];
 	sprintf(buffer, "border: %.0f %.0f %.0f %.0f", ee_borders[0], ee_borders[1], ee_borders[2], ee_borders[3]);
 	mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -856,7 +856,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 	int* ee_dimensions = getVideoModeDimensions(ee_videomode, reslist);
 
-	sScreenDimenions ee_screen;
+	sScreenDimensions ee_screen;
 	ee_screen.width = ee_dimensions[0];
 	ee_screen.height = ee_dimensions[1];
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -144,7 +144,7 @@ static std::string toupper(std::string s)
 	return s;
 }
 
-static  int* getVideoModeDimensions(std::string videomode, std::vector<std::string> reslist) 
+int* getVideoModeDimensions(std::string videomode, std::vector<std::string> reslist) 
 {
 	int screen[2] = {0, 0};
 	
@@ -854,7 +854,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		reslist.push_back("800 600");
 		reslist.push_back("640 480");
 
-	static auto ee_dimensions = getVideoModeDimensions(ee_videomode, reslist);
+	int* ee_dimensions = getVideoModeDimensions(ee_videomode, reslist);
 
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
 
@@ -897,12 +897,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 	std::string str_ee_offsets = SystemConf::getInstance()->get(ee_videomode+".ee_offsets");
 	
-	static float ee_borders[4] = {0.0,0.0,0.0,0.0};
+	float ee_borders[4] = {0.0,0.0,0.0,0.0};
 	memset(ee_borders, 0, 4*sizeof(*ee_borders));
-
-	char buffer[100];
-	sprintf(buffer, "%.0f %.0f %.0f %.0f", ee_borders[0], ee_borders[1], ee_borders[2], ee_borders[3]);
-	mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
 	if (!str_ee_offsets.empty()) {
 		std::vector<int> savedBorders = int_explode(str_ee_offsets, ' ');
@@ -929,23 +925,23 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		// borders
 		auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
 		leftborder->setValue(ee_borders[0]);
-		leftborder->setOnValueChanged([&ee_borders](const float &newVal) {
-			ee_borders[0] = Math::round(newVal);
+		leftborder->setOnValueChanged([](const float &newVal) {
+			//ee_borders[0] = Math::round(newVal);
 		});
 		auto topborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
 		topborder->setValue(ee_borders[1]);
-		topborder->setOnValueChanged([&ee_borders](const float &newVal) {
-			ee_borders[1] = Math::round(newVal);
+		topborder->setOnValueChanged([](const float &newVal) {
+			//ee_borders[1] = Math::round(newVal);
 		});
 		auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
 		rightborder->setValue(ee_borders[2]-ee_dimensions[0]+1);
-		rightborder->setOnValueChanged([&ee_borders](const float &newVal) {
-			ee_borders[2] = Math::round(newVal);
+		rightborder->setOnValueChanged([](const float &newVal) {
+			//ee_borders[2] = Math::round(newVal);
 		});
 		auto bottomborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
 		bottomborder->setValue(ee_borders[3]-ee_dimensions[1]+1);
-		bottomborder->setOnValueChanged([&ee_borders](const float &newVal) {
-			ee_borders[3] = Math::round(newVal);
+		bottomborder->setOnValueChanged([](const float &newVal) {
+			//ee_borders[3] = Math::round(newVal);
 		});
 
 		bordersConfig->addWithLabel(_("LEFT BORDER"), leftborder);
@@ -953,26 +949,32 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		bordersConfig->addWithLabel(_("TOP BORDER"), topborder);
 		bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
 
-		bordersConfig->addSaveFunc([mWindow, ee_videomode, ee_dimensions, &ee_borders]()
+		bordersConfig->addSaveFunc([mWindow, ee_videomode, ee_dimensions]()
 		{
+			float borders[4] = {0.0,0.0,0.0,0.0};
+			border[0] = leftborder->getValue();
+			border[1] = topborder->getValue();
+			border[2] = rightborder->getValue();
+			border[3] = bottomborder->getValue();
+
 			char buffer[100];
-			sprintf(buffer, "%.0f %.0f %.0f %.0f", ee_borders[0], ee_borders[1], ee_borders[2], ee_borders[3]);
+			sprintf(buffer, "%.0f %.0f %.0f %.0f", borders[0], borders[1], borders[2], borders[3]);
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 			
-			/*std::string result = std::to_string((int)ee_borders[0])+" "+
-				std::to_string((int)ee_borders[1])+" "+
-				std::to_string((int)ee_borders[2])+" "+
-				std::to_string((int)ee_borders[3]);
-			SystemConf::getInstance()->set(ee_videomode+".eeee_borders", result);*/
+			/*std::string result = std::to_string((int)borders[0])+" "+
+				std::to_string((int)borders[1])+" "+
+				std::to_string((int)borders[2])+" "+
+				std::to_string((int)borders[3]);
+			SystemConf::getInstance()->set(ee_videomode+".eeborders", result);*/
 
-			std::string result = std::to_string((int)ee_borders[0])+" "+
-				std::to_string((int)ee_borders[1])+" "+
-				std::to_string(ee_dimensions[0]-((int)ee_borders[2])-1)+" "+
-				std::to_string(ee_dimensions[1]-((int)ee_borders[3])-1);
+			std::string result = std::to_string((int)borders[0])+" "+
+				std::to_string((int)borders[1])+" "+
+				std::to_string(ee_dimensions[0]-((int)borders[2])-1)+" "+
+				std::to_string(ee_dimensions[1]-((int)borders[3])-1);
 			
 			SystemConf::getInstance()->set(ee_videomode+".ee_offsets", result);
-			//runSystemCommand("ee_setee_borders "+result, "", nullptr);
-			//delete [] ee_borders;
+			//runSystemCommand("ee_setborders "+result, "", nullptr);
+			//delete [] borders;
 		});
 
 		mWindow->pushGui(bordersConfig);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -146,10 +146,10 @@ static std::string toupper(std::string s)
 
 static int* getVideoModeDimensions(std::string ee_videomode, std::vector<std::string> reslist) 
 {
-	static int screen[2] = {0, 0};
-	int pos = 0;
+	int screen[2] = {0, 0};
+	int pos = ee_videomode.find('x');
 	std::string tmp;
-	pos = ee_videomode.find('x');
+
 	if (pos >= 0)
 	{
 		screen[0] = atoi(ee_videomode.substr(0, pos).c_str());
@@ -819,6 +819,10 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 #ifdef _ENABLEEMUELEC
 	std::string ee_videomode = SystemConf::getInstance()->get("ee_videomode");
 	std::string ee_framebuffer = SystemConf::getInstance()->get(ee_videomode+".ee_framebuffer");
+	if (ee_framebuffer.empty()) {
+		ee_framebuffer = "auto";
+	}
+
 	std::vector<std::string> reslist;
 		reslist.push_back("3840x2160");
 		reslist.push_back("1920x1080");
@@ -829,19 +833,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		reslist.push_back("800x600");
 		reslist.push_back("640x480");
 
-	int* dimensions = getVideoModeDimensions(ee_videomode,reslist);
-
-	int screenWidth = 0;
-	int screenHeight = 0;
-
-	if (!ee_framebuffer.empty()) {
-		int pos = ee_framebuffer.find('x');
-		screenWidth = atoi(ee_framebuffer.substr(0, pos).c_str());
-		screenHeight = atoi(ee_framebuffer.substr(pos+1).c_str());
-	}
-	else {
-		ee_framebuffer = "auto";
-	}
+	int* dimensions = getVideoModeDimensions(ee_videomode, reslist);
+	mWindow->displayNotificationMessage(_U("\uF011  ") + dimensions[0] + " " + dimensions[1]);
 
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
 
@@ -894,27 +887,30 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 		int borders[4] = {0,0,0,0};
     std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
-		std::vector<std::string> tmpBorders = explode(ee_borders, ' ');
+		std::vector<int> tmpBorders = int_explode(ee_borders, ' ');
 		for(int i=0; i < 4; ++i)
-			borders[i] = atoi(tmpBorders[i].c_str());
+			borders[i] = tmpBorders[i];
 
+		float width = float(dimensions[0])/2.0f;
+		float height = float(dimensions[1])/2.0f;
+		
 		// borders
-		auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(dimensions[0])/2.0f, 1.0f, "px");
+		auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
 		leftborder->setValue((float)borders[0]);
 		leftborder->setOnValueChanged([&borders](const float &newVal) {
 			borders[0] = (int)Math::round(newVal);
 		});
-		auto topborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(dimensions[1])/2.0f, 1.0f, "px");
+		auto topborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
 		topborder->setValue((float)borders[1]);
 		topborder->setOnValueChanged([&borders](const float &newVal) {
 			borders[1] = (int)Math::round(newVal);
 		});
-		auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(dimensions[0])/2.0f, 1.0f, "px");
+		auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
 		rightborder->setValue((float)borders[2]);
 		rightborder->setOnValueChanged([&borders](const float &newVal) {
 			borders[2] = (int)Math::round(newVal);
 		});
-		auto bottomborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(dimensions[1])/2.0f, 1.0f, "px");
+		auto bottomborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
 		bottomborder->setValue((float)borders[3]);
 		bottomborder->setOnValueChanged([&borders](const float &newVal) {
 			borders[3] = (int)Math::round(newVal);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -867,7 +867,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	dangerZone->addWithLabel(_("FRAME BUFFER"), emuelec_frame_buffer);
 
 	auto fbSave = [mWindow, emuelec_frame_buffer, ee_videomode, dimensions] (std::string selectedFB) {
-		if (emuelec_frame_buffer.changed()) {
+		if (emuelec_frame_buffer->changed()) {
 			if (selectedFB == "auto")
 				selectedFB = "";
 
@@ -896,7 +896,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	});
 
 	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions] {
-		std::string ee_borders = SystemConf::getInstance()->get(*ee_videomode+".ee_borders");
+		std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
 		int borders[4] = {0,0,0,0};
 		if (!ee_borders.empty()) {
 			std::vector<int> savedBorders = int_explode(ee_borders, ' ');
@@ -907,7 +907,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		}
 
 		GuiSettings* bordersConfig = new GuiSettings(mWindow, _("FRAME BORDERS"));
-		if (ee_framebuffer->empty())
+		if (ee_framebuffer.empty())
 			return;
 
 		auto saveBorders = [mWindow, ee_videomode, borders]() {
@@ -915,7 +915,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				std::to_string(borders[1])+" "+
 				std::to_string(borders[2])+" "+
 				std::to_string(borders[3]);
-			SystemConf::getInstance()->set(*ee_videomode+".ee_borders", result);
+			SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);
 		};
 			
 		float width = float(dimensions[0])/2.0f;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -813,13 +813,13 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			leftborder->setValue((float)borders[0]);
 			leftborder->setOnValueChanged([&borders](const float &newVal) {
 				borders[0] = (int)Math::round(newVal);
-				rightborder->setValue((float)borders[0]);
+				//rightborder->setValue((float)borders[0]);
 			});
 			auto topborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenHeight)/2.0f, 1.0f, "px");
 			topborder->setValue((float)borders[1]);
 			topborder->setOnValueChanged([&borders](const float &newVal) {
 				borders[1] = (int)Math::round(newVal);
-				bottomborder->setValue((float)borders[1]);
+				//bottomborder->setValue((float)borders[1]);
 			});
 			auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenWidth)/2.0f, 1.0f, "px");
 			rightborder->setValue((float)borders[2]);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -144,9 +144,9 @@ static std::string toupper(std::string s)
 	return s;
 }
 
-int* getVideoModeDimensions(std::string videomode, std::vector<std::string> reslist) 
+static int* getVideoModeDimensions(std::string videomode, std::vector<std::string> reslist) 
 {
-	int screen[2] = {0, 0};
+	static int screen[2] = {0, 0};
 	
 	if (videomode == "480cvbs")
 	{

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -967,26 +967,26 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 		bordersConfig->addSaveFunc([mWindow, ee_videomode, ee_screen, leftborder, rightborder, topborder, bottomborder]()
 		{
-			float borders[4] = {0.0,0.0,0.0,0.0};
-			borders[0] = leftborder->getValue();
-			borders[1] = topborder->getValue();
-			borders[2] = rightborder->getValue();
-			borders[3] = bottomborder->getValue();
+			int borders[4] = {0,0,0,0};
+			borders[0] = (int) leftborder->getValue();
+			borders[1] = (int) topborder->getValue();
+			borders[2] = (int) rightborder->getValue();
+			borders[3] = (int) bottomborder->getValue();
 
 			char buffer[100];
-			sprintf(buffer, "border: %.0f %.0f %.0f %.0f", borders[0], borders[1], borders[2], borders[3]);
+			sprintf(buffer, "border: %d %d %d %d", borders[0], borders[1], borders[2], borders[3]);
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
 			sprintf(buffer, "dim: %d %d", ee_screen.width, ee_screen.height);
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 			
-			/*std::string result = std::to_string((int)borders[0])+" "+
-				std::to_string((int)borders[1])+" "+
-				std::to_string(ee_screen.width-((int)borders[2])-1)+" "+
-				std::to_string(ee_screen.height-((int)borders[3])-1);
+			std::string result = std::to_string(borders[0])+" "+
+				std::to_string(borders[1])+" "+
+				std::to_string(ee_screen.width-(borders[2])-1)+" "+
+				std::to_string(ee_screen.height-(borders[3])-1);
 
 			SystemConf::getInstance()->set(ee_videomode+".ee_offsets", result);
-			runSystemCommand("ee_setborders "+result, "", nullptr);*/
+			//runSystemCommand("ee_setborders "+result, "", nullptr);
 		});
 
 		mWindow->pushGui(bordersConfig);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -817,16 +817,9 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 			int borders[4] = {0,0,0,0};
 	    std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
-			if (!ee_borders.empty()) 
-			{
-		    std::stringstream data(ee_borders);
-		    std::string line;
-				int i=0;
-		    while(std::getline(data,line,' '))
-		    {
-		        borders[i++] = atoi(line.c_str());
-		    }
-			}
+			std::vector<std::string> tmpBorders = explode(ee_borders, ' ');
+			for(int i=0; i < 4; ++i)
+				borders[i] = atoi(tmpBorders.c_str());
 
 			// borders
 			auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenWidth)/2.0f, 1.0f, "px");

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -746,46 +746,43 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 #endif
 
 #ifdef _ENABLEEMUELEC
-			std::string ee_videomode = SystemConf::getInstance()->get("ee_videomode");
-			std::string ee_framebuffer = SystemConf::getInstance()->get(ee_videomode+".ee_framebuffer");
+	std::string ee_videomode = SystemConf::getInstance()->get("ee_videomode");
+	std::string ee_framebuffer = SystemConf::getInstance()->get(ee_videomode+".ee_framebuffer");
 
-			auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
-		        std::vector<std::string> framebuffer;
-				framebuffer.push_back("auto");
-				framebuffer.push_back("3840x2160");
-				framebuffer.push_back("1920x1080");
-				framebuffer.push_back("1280x720");
-				framebuffer.push_back("720x480");
-				framebuffer.push_back("1280x1024");
-				framebuffer.push_back("1024x768");
-				framebuffer.push_back("800x600");
-				framebuffer.push_back("640x480");
-				if (ee_framebuffer.empty())
-					ee_framebuffer = "auto";
-								
-				for (auto it = framebuffer.cbegin(); it != framebuffer.cend(); it++) {
-					emuelec_frame_buffer->add(*it, *it, ee_framebuffer == *it); }
-				dangerZone->addWithLabel(_("FRAME BUFFER"), emuelec_frame_buffer);
-			   	
-				dangerZone->addSaveFunc([this, emuelec_frame_buffer, window] {
-					if (emuelec_video_mode->changed()) {
-						std::string selectedFB = emuelec_frame_buffer->getSelected();
-						int pos = selectedFB.find('x');
-						std::string screenWidth = selectedFB.substr(0, pos);
-						std::string screenHeight = selectedFB.substr(pos+1);
+	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
+        std::vector<std::string> framebuffer;
+		framebuffer.push_back("auto");
+		framebuffer.push_back("3840x2160");
+		framebuffer.push_back("1920x1080");
+		framebuffer.push_back("1280x720");
+		framebuffer.push_back("720x480");
+		framebuffer.push_back("1280x1024");
+		framebuffer.push_back("1024x768");
+		framebuffer.push_back("800x600");
+		framebuffer.push_back("640x480");
+		if (ee_framebuffer.empty())
+			ee_framebuffer = "auto";
+						
+		for (auto it = framebuffer.cbegin(); it != framebuffer.cend(); it++) {
+			emuelec_frame_buffer->add(*it, *it, ee_framebuffer == *it); }
+		dangerZone->addWithLabel(_("FRAME BUFFER"), emuelec_frame_buffer);
+	   	
+		dangerZone->addSaveFunc([mWindow, emuelec_video_mode, emuelec_frame_buffer, ee_videomode] {
+			if (emuelec_video_mode->changed()) {
+				std::string selectedFB = emuelec_frame_buffer->getSelected();
+				int pos = selectedFB.find('x');
+				std::string screenWidth = selectedFB.substr(0, pos);
+				std::string screenHeight = selectedFB.substr(pos+1);
 
-						std::string ee_videomode = SystemConf::getInstance()->get("ee_videomode");
-						SystemConf::getInstance()->set(ee_videomode+".ee_framebuffer", screenWidth+" "+screenHeight);
-					}
-					mWindow->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
-				});
+				std::string ee_videomode = SystemConf::getInstance()->get("ee_videomode");
+				SystemConf::getInstance()->set(ee_videomode+".ee_framebuffer", screenWidth+" "+screenHeight);
+			}
+			mWindow->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
 		});
 
 		if (!ee_framebuffer.empty() && ee_framebuffer != "auto") {
-			dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow] { 
+			dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer] { 
 				GuiSettings* bordersConfig = new GuiSettings(window, _("FRAME BORDERS"));
-				std::string ee_videomode = SystemConf::getInstance()->get("ee_videomode");
-				std::string ee_framebuffer = SystemConf::getInstance()->get(ee_videomode+".ee_framebuffer");
 				if (ee_framebuffer.empty())
 					return;
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -930,7 +930,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 		bordersConfig->addSaveFunc([mWindow, ee_videomode, dimensions, borders]()
 		{
-			mWindow->displayNotificationMessage(_U("\uF011  ") + ("bordersConfig->addSaveFunc"));
+			mWindow->displayNotificationMessage(_U("\uF011  ") + _("bordersConfig->addSaveFunc"));
 			bool hasBorder = false;
 			for(int i=0; i < 4; ++i) {
 				if (borders[i] > 0) {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -906,6 +906,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	});
 
 	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, ee_screen] {
+		char buffer[100];
 
 		static sScreenBorders ee_borders;
 		ee_borders.left = 0.0f;
@@ -916,6 +917,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		std::string str_ee_offsets = SystemConf::getInstance()->get(ee_videomode+".ee_offsets");
 		if (!str_ee_offsets.empty()) {
 			std::vector<int> savedBorders = int_explode(str_ee_offsets, ' ');
+			sprintf(buffer, "size: %d", savedBorders.size());
+			mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));			
 			if (savedBorders.size() == 4) {
 				ee_borders.left = (float) savedBorders[0];
 				ee_borders.top = (float) savedBorders[1];
@@ -923,8 +926,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				ee_borders.bottom = (float) savedBorders[3];
 			}
 		}
-		
-		char buffer[100];
+
 		sprintf(buffer, "border: %.0f %.0f %.0f %.0f", ee_borders.left, ee_borders.top, ee_borders.right, ee_borders.bottom);
 		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -797,35 +797,35 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 					return;
 
 
-				std::vector<std::string> borders;
+				std::vector<int> borders;
 		    std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
 		    std::stringstream data(ee_borders);
 		    std::string line;
 		    while(std::getline(data,line,' '))
 		    {
-		        borders.push_back(line);
+		        borders.push_back(atoi(line));
 		    }
 
 				// borders
-				auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.f, float(screenWidth)/2.0f, 1.f, "px");
-				leftborder->setValue((float)borders[0]);
-				leftborder->setOnValueChanged([this, borders](const float &newVal) {
-					borders[0] = (int)Math::round(newVal);
+				auto leftborder = std::make_shared<SliderComponent>(mWindow, 0, int(screenWidth)/2, 1, "px");
+				leftborder->setValue((int)borders[0]);
+				leftborder->setOnValueChanged([this, borders](const int &newVal) {
+					borders[0] = (int)(newVal);
 				});
-				auto topborder = std::make_shared<SliderComponent>(mWindow, 0.f, float(screenHeight)/2.0f, 1.f, "px");
-				topborder->setValue((float)borders[1]);
-				topborder->setOnValueChanged([this, borders](const float &newVal) {
-					borders[1] = (int)Math::round(newVal);
+				auto topborder = std::make_shared<SliderComponent>(mWindow, 0, int(screenHeight)/2, 1, "px");
+				topborder->setValue((int)borders[1]);
+				topborder->setOnValueChanged([this, borders](const int &newVal) {
+					borders[1] = (int)(newVal);
 				});
-				auto rightborder = std::make_shared<SliderComponent>(mWindow, float(screenWidth)-1.0f, float(screenWidth)/2.0f, -1.f, "px");
-				rightborder->setValue((float)borders[2]);
-				rightborder->setOnValueChanged([this, borders](const float &newVal) {
-					borders[2] = (int)Math::round(newVal);
+				auto rightborder = std::make_shared<SliderComponent>(mWindow, int(screenWidth)-1, int(screenWidth)/2, -1, "px");
+				rightborder->setValue((int)borders[2]);
+				rightborder->setOnValueChanged([this, borders](const int &newVal) {
+					borders[2] = (int)(newVal);
 				});
-				auto bottomborder = std::make_shared<SliderComponent>(mWindow, float(screenHeight)-1.0f, float(screenHeight)/2.0f, -1.f, "px");
-				bottomborder->setValue((float)borders[3]);
-				bottomborder->setOnValueChanged([this, borders](const float &newVal) {
-					borders[3] = (int)Math::round(newVal);
+				auto bottomborder = std::make_shared<SliderComponent>(mWindow, int(screenHeight)-1, int(screenHeight)/2, -1, "px");
+				bottomborder->setValue((int)borders[3]);
+				bottomborder->setOnValueChanged([this, borders](const int &newVal) {
+					borders[3] = (int)(newVal);
 				});
 
 				bordersConfig->addWithLabel(_("LEFT BORDER"), leftborder);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -854,10 +854,10 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		reslist.push_back("800 600");
 		reslist.push_back("640 480");
 
-	auto ee_dimensions = std::make_shared<int*>(getVideoModeDimensions(ee_videomode, reslist));
+	auto ee_dimensions = std::make_shared<int>(getVideoModeDimensions(ee_videomode, reslist));
 
 	char buffer[100];
-	sprintf(buffer, "dimensions: %.0f %.0f", **ee_dimensions[0], **ee_dimensions[1]);
+	sprintf(buffer, "dimensions: %.0f %.0f", ee_dimensions[0], ee_dimensions[1]);
 	mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -820,6 +820,9 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	if (ee_framebuffer.empty()) {
 		ee_framebuffer = "auto";
 	}
+	else {
+		selectedFB.replace(selectedFB.find(" "),1,"x");
+	}
 
 	std::vector<std::string> reslist;
 		reslist.push_back("3840x2160");
@@ -846,6 +849,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		if (emuelec_frame_buffer->changed()) {
 			if (selectedFB == "auto")
 				selectedFB = "";
+			else
+				selectedFB.replace(selectedFB.find("x"),1," ");
 
 			SystemConf::getInstance()->set(ee_videomode+".ee_framebuffer", selectedFB);
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
@@ -859,7 +864,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			if (!ee_offsets.empty())
 				return;
 
-			int pos = selectedFB.find('x');
+			int pos = selectedFB.find(' ');
 			int width = atoi(selectedFB.substr(0, pos).c_str());
 			int height = atoi(selectedFB.substr(pos+1).c_str());
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -146,7 +146,7 @@ static std::string toupper(std::string s)
 
 int* getVideoModeDimensions(std::string videomode, std::vector<std::string> reslist) 
 {
-	static int screen[2]();
+	static int screen[2];
 
 	if (videomode == "480cvbs")
 	{

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -897,7 +897,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 	std::string str_ee_offsets = SystemConf::getInstance()->get(ee_videomode+".ee_offsets");
 	
-	static float[4] ee_borders = {0.0,0.0,0.0,0.0};
+	static float ee_borders[4] = {0.0,0.0,0.0,0.0};
 	memset(ee_borders, 0, 4*sizeof(*ee_borders));
 
 	char buffer[100];

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -798,33 +798,40 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 			std::vector<int> borders;
 	    std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
-	    std::stringstream data(ee_borders);
-	    std::string line;
-	    while(std::getline(data,line,' '))
-	    {
-	        borders.push_back(atoi(line.c_str()));
-	    }
+			if (ee_borders.empty())
+			{
+				for (int i=0; i < 4; ++i)
+					borders.push_back(0);
+			}
+			else {
+		    std::stringstream data(ee_borders);
+		    std::string line;
+		    while(std::getline(data,line,' '))
+		    {
+		        borders.push_back(atoi(line.c_str()));
+		    }
+			}
 
 			// borders
 			auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenWidth)/2.0f, 1.0f, "px");
-			leftborder->setValue((int)borders[0]);
+			leftborder->setValue((float)borders[0]);
 			leftborder->setOnValueChanged([&borders](const float &newVal) {
 				borders[0] = (int)Math::round(newVal);
 			});
 			auto topborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenHeight)/2.0f, 1.0f, "px");
-			topborder->setValue((int)borders[1]);
+			topborder->setValue((float)borders[1]);
 			topborder->setOnValueChanged([&borders](const float &newVal) {
 				borders[1] = (int)Math::round(newVal);
 			});
 			auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenWidth)/2.0f, 1.0f, "px");
-			rightborder->setValue((int)borders[2]);
-			rightborder->setOnValueChanged([&borders](const float &newVal) {
+			rightborder->setValue((float)borders[2]);
+			rightborder->setOnValueChanged([&borders,screenWidth](const float &newVal) {
 				borders[2] = screenWidth-1-(int)Math::round(newVal);
 			});
 			auto bottomborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenHeight)/2.0f, 1.0f, "px");
-			bottomborder->setValue((int)borders[3]);
-			bottomborder->setOnValueChanged([&borders](const float &newVal) {
-				borders[3] = (int)Math::round(newVal);
+			bottomborder->setValue((float)borders[3]);
+			bottomborder->setOnValueChanged([&borders,screenHeight](const float &newVal) {
+				borders[3] = screenHeight-1-(int)Math::round(newVal);
 			});
 
 			bordersConfig->addWithLabel(_("LEFT BORDER"), leftborder);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -854,7 +854,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		reslist.push_back("800 600");
 		reslist.push_back("640 480");
 
-	int* ee_dimensions = getVideoModeDimensions(ee_videomode, reslist));
+	int* ee_dimensions = getVideoModeDimensions(ee_videomode, reslist);
 
 	char buffer[100];
 	sprintf(buffer, "dimensions: %d %d", ee_dimensions[0], ee_dimensions[1]);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -821,7 +821,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		ee_framebuffer = "auto";
 	}
 	else {
-		selectedFB.replace(selectedFB.find(" "),1,"x");
+		ee_framebuffer.replace(ee_framebuffer.find(" "),1,"x");
 	}
 
 	std::vector<std::string> reslist;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -910,7 +910,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	sprintf(buffer, "%.0f %.0f %.0f %.0f", _borders[0], _borders[1], _borders[2], _borders[3]);
 	mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
-	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions, _borders] {
+	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions, &_borders] {
 		char buffer[100];
 		sprintf(buffer, "%.0f %.0f %.0f %.0f", _borders[0], _borders[1], _borders[2], _borders[3]);
 		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -965,7 +965,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		bordersConfig->addWithLabel(_("TOP BORDER"), topborder);
 		bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
 
-		bordersConfig->addSaveFunc([mWindow, ee_videomode, ee_screen, leftborder,rightborder,topborder,bottomborder]()
+		bordersConfig->addSaveFunc([mWindow, ee_videomode, ee_screen, leftborder, rightborder, topborder, bottomborder]()
 		{
 			float borders[4] = {0.0,0.0,0.0,0.0};
 			borders[0] = leftborder->getValue();
@@ -980,13 +980,13 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			sprintf(buffer, "dim: %d %d", ee_screen.width, ee_screen.height);
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 			
-			std::string result = std::to_string((int)borders[0])+" "+
+			/*std::string result = std::to_string((int)borders[0])+" "+
 				std::to_string((int)borders[1])+" "+
 				std::to_string(ee_screen.width-((int)borders[2])-1)+" "+
 				std::to_string(ee_screen.height-((int)borders[3])-1);
 
 			SystemConf::getInstance()->set(ee_videomode+".ee_offsets", result);
-			runSystemCommand("ee_setborders "+result, "", nullptr);
+			runSystemCommand("ee_setborders "+result, "", nullptr);*/
 		});
 
 		mWindow->pushGui(bordersConfig);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -820,6 +820,10 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	if (ee_framebuffer.empty()) {
 		ee_framebuffer = "auto";
 	}
+	std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
+	std::vector<int> borders(4); 
+	if (!ee_borders.empty())
+		borders = int_explode(ee_borders, ' '); 
 
 	std::vector<std::string> reslist;
 		reslist.push_back("3840x2160");
@@ -876,7 +880,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		fbSave(name);
 	});
 
-	dangerZone->addSaveFunc([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, dimensions]()
+	dangerZone->addSaveFunc([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, dimensions, borders]()
 	{
 		std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
 		if (ee_borders.empty())
@@ -885,7 +889,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		std::vector<int> borders = int_explode(ee_borders, ' ');
 		bool hasBorder = false;
 		for(int i=0; i < 4; ++i) {
-			if (tmpBorders[i] > 0) {
+			if (borders[i] > 0) {
 				hasBorder=true;
 				break;
 			}
@@ -907,10 +911,6 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		if (ee_framebuffer.empty())
 			return;
 
-    std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
-		std::vector<int> borders(4); 
-		if (!ee_borders.empty())
-			borders = int_explode(ee_borders, ' '); 
 
 		auto saveBorders = [ee_videomode,dimensions,borders]() {
 			std::string result = std::to_string(borders[0])+" "+
@@ -926,25 +926,25 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		// borders
 		auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
 		leftborder->setValue((float)borders[0]);
-		leftborder->setOnValueChanged([&borders](const float &newVal) {
+		leftborder->setOnValueChanged([&borders, saveBorders](const float &newVal) {
 			borders[0] = (int)Math::round(newVal);
 			saveBorders();
 		});
 		auto topborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
 		topborder->setValue((float)borders[1]);
-		topborder->setOnValueChanged([&borders](const float &newVal) {
+		topborder->setOnValueChanged([&borders, saveBorders](const float &newVal) {
 			borders[1] = (int)Math::round(newVal);
 			saveBorders();
 		});
 		auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
 		rightborder->setValue((float)borders[2]);
-		rightborder->setOnValueChanged([&borders](const float &newVal) {
+		rightborder->setOnValueChanged([&borders, saveBorders](const float &newVal) {
 			borders[2] = (int)Math::round(newVal);
 			saveBorders();
 		});
 		auto bottomborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
 		bottomborder->setValue((float)borders[3]);
-		bottomborder->setOnValueChanged([&borders](const float &newVal) {
+		bottomborder->setOnValueChanged([&borders, saveBorders](const float &newVal) {
 			borders[3] = (int)Math::round(newVal);
 			saveBorders();
 		});

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -147,6 +147,20 @@ static std::string toupper(std::string s)
 static int* getVideoModeDimensions(std::string ee_videomode, std::vector<std::string> reslist) 
 {
 	static int screen[2] = {0, 0};
+	
+	if (ee_videomode == "480cvbs")
+	{
+		screen[0] = 720;
+		screen[1] = 480;
+		return screen;
+  }
+	else if (ee_videomode == "576cvbs")
+	{
+		screen[0] = 720;
+		screen[1] = 576;
+		return screen;
+  }
+	
 	int pos = ee_videomode.find('x');
 	std::string tmp = ee_videomode;
 
@@ -826,10 +840,16 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 	std::vector<std::string> reslist;
 		reslist.push_back("3840x2160");
+		reslist.push_back("2560x1440");
 		reslist.push_back("1920x1080");
 		reslist.push_back("1280x720");
 		reslist.push_back("720x480");
+		reslist.push_back("768x576");
+		reslist.push_back("1680x1050");
+		reslist.push_back("1440x900");
 		reslist.push_back("1280x1024");
+		reslist.push_back("1280x960");
+		reslist.push_back("1280x800");
 		reslist.push_back("1024x768");
 		reslist.push_back("800x600");
 		reslist.push_back("640x480");
@@ -883,7 +903,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions] {
 		std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
-		mWindow->displayNotificationMessage(_U("\uF011  ") + _(ee_borders.c_str()));
+		//mWindow->displayNotificationMessage(_U("\uF011  ") + _(ee_borders.c_str()));
 		static int borders[4] = {0, 0, 0, 0};
 		if (!ee_borders.empty()) {
 			std::vector<int> savedBorders = int_explode(ee_borders, ' ');
@@ -898,7 +918,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			return;
 
 		auto saveBorders = [mWindow, ee_videomode, borders]() {
-			mWindow->displayNotificationMessage(_U("\uF011  ") + _("saveBorders"));
+			//mWindow->displayNotificationMessage(_U("\uF011  ") + _("saveBorders"));
 			std::string result = std::to_string(borders[0])+" "+
 				std::to_string(borders[1])+" "+
 				std::to_string(borders[2])+" "+
@@ -938,7 +958,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 		bordersConfig->addSaveFunc([mWindow, saveBorders, ee_videomode, dimensions, borders]()
 		{
-			mWindow->displayNotificationMessage(_U("\uF011  ") + _("bordersConfig->addSaveFunc"));
+			//mWindow->displayNotificationMessage(_U("\uF011  ") + _("bordersConfig->addSaveFunc"));
 
 			saveBorders();
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -894,7 +894,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
     std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
 		std::vector<std::string> tmpBorders = explode(ee_borders, ' ');
 		for(int i=0; i < 4; ++i)
-			borders[i] = atoi(tmpBorders.c_str());
+			borders[i] = atoi(tmpBorders[i].c_str());
 
 		// borders
 		auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(dimensions[0])/2.0f, 1.0f, "px");

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -861,8 +861,6 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			}
 			
 			std::string ee_offsets = SystemConf::getInstance()->get(ee_videomode+".ee_offsets");
-			if (!ee_offsets.empty())
-				return;
 
 			int pos = selectedFB.find(' ');
 			int width = atoi(selectedFB.substr(0, pos).c_str());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -144,7 +144,7 @@ static std::string toupper(std::string s)
 	return s;
 }
 
-static int* getVideoModeDimensions(std::string ee_videomode, std::vector<std::string> reslist) 
+static  int* getVideoModeDimensions(std::string ee_videomode, std::vector<std::string> reslist) 
 {
 	int screen[2] = {0, 0};
 	

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -821,9 +821,13 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		ee_framebuffer = "auto";
 	}
 	std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
-	int* borders;
-	if (!ee_borders.empty())
-		borders = &int_explode(ee_borders, ' ')[0]; 
+	mWindow->displayNotificationMessage(_U("\uF011  ") + _(ee_borders.c_str()));
+	int borders[4] = {0, 0, 0, 0};
+	std::vector<int> savedBorders = int_explode(ee_borders, ' ');
+	if (savedBorders && saveBorders.size() == 4) {
+		for(var i=0; i < 4; ++i)
+			borders[i] = savedBorders[i];
+	}
 
 	std::vector<std::string> reslist;
 		reslist.push_back("3840x2160");

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -899,13 +899,16 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions] {
 		std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
-		static int _borders[4] = {0,0,0,0};
+		int* _borders = new int[4];
 		if (!ee_borders.empty()) {
 			std::vector<int> savedBorders = int_explode(ee_borders, ' ');
 			if (savedBorders.size() == 4) {
 				for(int i=0; i < 4; ++i)
 					_borders[i] = savedBorders[i];
 			}
+		} else {
+			for(int i=0; i < 4; ++i)
+				_borders[i] = 0;
 		}
 
 		GuiSettings* bordersConfig = new GuiSettings(mWindow, _("FRAME BORDERS"));
@@ -918,22 +921,22 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		// borders
 		auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
 		leftborder->setValue((float)_borders[0]);
-		leftborder->setOnValueChanged([&_borders](const float &newVal) {
+		leftborder->setOnValueChanged([_borders](const float &newVal) {
 			_borders[0] = (int)Math::round(newVal);
 		});
 		auto topborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
 		topborder->setValue((float)_borders[1]);
-		topborder->setOnValueChanged([&_borders](const float &newVal) {
+		topborder->setOnValueChanged([_borders](const float &newVal) {
 			_borders[1] = (int)Math::round(newVal);
 		});
 		auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
 		rightborder->setValue((float)_borders[2]);
-		rightborder->setOnValueChanged([&_borders](const float &newVal) {
+		rightborder->setOnValueChanged([_borders](const float &newVal) {
 			_borders[2] = (int)Math::round(newVal);
 		});
 		auto bottomborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
 		bottomborder->setValue((float)_borders[3]);
-		bottomborder->setOnValueChanged([&_borders](const float &newVal) {
+		bottomborder->setOnValueChanged([_borders](const float &newVal) {
 			_borders[3] = (int)Math::round(newVal);
 		});
 
@@ -957,7 +960,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			
 			SystemConf::getInstance()->set(ee_videomode+".ee_offsets", result);
 			//runSystemCommand("ee_set_borders "+result, "", nullptr);
-			delete _borders;
+			delete [] _borders;
 		});
 
 		mWindow->pushGui(bordersConfig);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -810,22 +810,22 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				auto leftborder = std::make_shared<SliderComponent>(mWindow, 0, int(screenWidth)/2, 1, "px");
 				leftborder->setValue((int)borders[0]);
 				leftborder->setOnValueChanged([borders](const int &newVal) {
-					borders[0] = (int)newVal;
+					borders[0] = newVal;
 				});
 				auto topborder = std::make_shared<SliderComponent>(mWindow, 0, int(screenHeight)/2, 1, "px");
 				topborder->setValue((int)borders[1]);
 				topborder->setOnValueChanged([borders](const int &newVal) {
-					borders[1] = (int)newVal;
+					borders[1] = newVal;
 				});
 				auto rightborder = std::make_shared<SliderComponent>(mWindow, int(screenWidth)-1, int(screenWidth)/2, -1, "px");
 				rightborder->setValue((int)borders[2]);
 				rightborder->setOnValueChanged([borders](const int &newVal) {
-					borders[2] = (int)newVal;
+					borders[2] = newVal;
 				});
 				auto bottomborder = std::make_shared<SliderComponent>(mWindow, int(screenHeight)-1, int(screenHeight)/2, -1, "px");
 				bottomborder->setValue((int)borders[3]);
 				bottomborder->setOnValueChanged([borders](const int &newVal) {
-					borders[3] = (int)newVal;
+					borders[3] = newVal;
 				});
 
 				bordersConfig->addWithLabel(_("LEFT BORDER"), leftborder);
@@ -835,8 +835,10 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 				bordersConfig->addSaveFunc([ee_videomode, borders]
 				{
-					std::string result = to_string(borders[0])+" "+to_string(borders[1])+
-						" "+to_string(borders[2])+" "+to_string(borders[3]);
+					std::string result = std::to_string(borders[0])+" "+
+						std::to_string(borders[1])+" "+
+						std::to_string(borders[2])+" "+
+						std::to_string(borders[3]);
 					SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);
 					runSystemCommand("ee_set_borders "+result, "", nullptr);
 				});

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -977,7 +977,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			sprintf(buffer, "border: %.0f %.0f %.0f %.0f", borders[0], borders[1], borders[2], borders[3]);
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
-			sprintf(buffer, "dim: %.0f %.0f", ee_screen.width, ee_screen.height);
+			sprintf(buffer, "dim: %d %d", ee_screen.width, ee_screen.height);
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 			
 			std::string result = std::to_string((int)borders[0])+" "+

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -854,10 +854,10 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		reslist.push_back("800 600");
 		reslist.push_back("640 480");
 
-	auto ee_dimensions = std::make_shared<int*>(getVideoModeDimensions(ee_videomode, reslist));
+	int* ee_dimensions = getVideoModeDimensions(ee_videomode, reslist));
 
 	char buffer[100];
-	sprintf(buffer, "dimensions: %d %d", *ee_dimensions.get()[0], *ee_dimensions.get()[1]);
+	sprintf(buffer, "dimensions: %d %d", ee_dimensions[0], ee_dimensions[1]);
 	mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
@@ -883,8 +883,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				return;
 			}
 			
-			int width = *ee_dimensions.get()[0];
-			int height = *ee_dimensions.get()[1];
+			int width = ee_dimensions[0];
+			int height = ee_dimensions[1];
 
 			std::string result = "0 0 "+
 				std::to_string(width-1)+" "+
@@ -897,7 +897,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	emuelec_frame_buffer->setSelectedChangedCallback([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, ee_dimensions](std::string name)
 	{
 		char buffer[100];
-		sprintf(buffer, "dim: %.0f %.0f", *ee_dimensions.get()[0], *ee_dimensions.get()[1]);
+		sprintf(buffer, "dim: %d %d", ee_dimensions[0], ee_dimensions[1]);
 		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 				
 		fbSave(emuelec_frame_buffer->getSelected());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -854,8 +854,15 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		reslist.push_back("800 600");
 		reslist.push_back("640 480");
 
-	int* ee_dimensions = getVideoModeDimensions(ee_videomode, reslist);
+	int* dimensions = getVideoModeDimensions(ee_videomode, reslist);
 
+	std::shared_ptr<int> ee_dimensions (new int [2], [](int* d){
+		 delete [] d;
+	});
+	ee_dimensions.get()[0] = dimensions[0];
+	ee_dimensions.get()[1] = dimensions[1];
+	
+	
 	//char buffer[100];
 	//sprintf(buffer, "dimensions: %d %d", ee_dimensions[0], ee_dimensions[1]);
 	//mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
@@ -870,7 +877,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	}
 	dangerZone->addWithLabel(_("FRAME BUFFER"), emuelec_frame_buffer);
 
-	auto fbSave = [mWindow, emuelec_frame_buffer, ee_videomode, &ee_dimensions] (std::string selectedFB) {
+	auto fbSave = [mWindow, emuelec_frame_buffer, ee_videomode, ee_dimensions] (std::string selectedFB) {
 		if (emuelec_frame_buffer->changed()) {
 			if (selectedFB == "auto")
 				selectedFB = "";
@@ -883,8 +890,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				return;
 			}
 			
-			int width = ee_dimensions[0];
-			int height = ee_dimensions[1];
+			int width = ee_dimensions.get()[0];
+			int height = ee_dimensions.get()[1];
 
 			std::string result = "0 0 "+
 				std::to_string(width-1)+" "+
@@ -894,10 +901,10 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		}
 	};
 
-	emuelec_frame_buffer->setSelectedChangedCallback([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, &ee_dimensions](std::string name)
+	emuelec_frame_buffer->setSelectedChangedCallback([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, ee_dimensions](std::string name)
 	{
 		char buffer[100];
-		sprintf(buffer, "dim: %d %d", ee_dimensions[0], ee_dimensions[1]);
+		sprintf(buffer, "dim: %d %d", ee_dimensions.get()[0], ee_dimensions.get()[1]);
 		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 				
 		fbSave(emuelec_frame_buffer->getSelected());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -823,10 +823,12 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
 	mWindow->displayNotificationMessage(_U("\uF011  ") + _(ee_borders.c_str()));
 	int borders[4] = {0, 0, 0, 0};
-	std::vector<int> savedBorders = int_explode(ee_borders, ' ');
-	if (savedBorders && saveBorders.size() == 4) {
-		for(var i=0; i < 4; ++i)
-			borders[i] = savedBorders[i];
+	if (!ee_borders.empty()) {
+		std::vector<int> savedBorders = int_explode(ee_borders, ' ');
+		if (savedBorders && saveBorders.size() == 4) {
+			for(var i=0; i < 4; ++i)
+				borders[i] = savedBorders[i];
+		}
 	}
 
 	std::vector<std::string> reslist;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -803,29 +803,29 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		    std::string line;
 		    while(std::getline(data,line,' '))
 		    {
-		        borders.push_back(atoi(line));
+		        borders.push_back(atoi(line.c_str()));
 		    }
 
 				// borders
 				auto leftborder = std::make_shared<SliderComponent>(mWindow, 0, int(screenWidth)/2, 1, "px");
 				leftborder->setValue((int)borders[0]);
-				leftborder->setOnValueChanged([this, borders](const int &newVal) {
-					borders[0] = (int)(newVal);
+				leftborder->setOnValueChanged([borders](const int &newVal) {
+					borders[0] = (int)newVal;
 				});
 				auto topborder = std::make_shared<SliderComponent>(mWindow, 0, int(screenHeight)/2, 1, "px");
 				topborder->setValue((int)borders[1]);
-				topborder->setOnValueChanged([this, borders](const int &newVal) {
-					borders[1] = (int)(newVal);
+				topborder->setOnValueChanged([borders](const int &newVal) {
+					borders[1] = (int)newVal;
 				});
 				auto rightborder = std::make_shared<SliderComponent>(mWindow, int(screenWidth)-1, int(screenWidth)/2, -1, "px");
 				rightborder->setValue((int)borders[2]);
-				rightborder->setOnValueChanged([this, borders](const int &newVal) {
-					borders[2] = (int)(newVal);
+				rightborder->setOnValueChanged([borders](const int &newVal) {
+					borders[2] = (int)newVal;
 				});
 				auto bottomborder = std::make_shared<SliderComponent>(mWindow, int(screenHeight)-1, int(screenHeight)/2, -1, "px");
 				bottomborder->setValue((int)borders[3]);
-				bottomborder->setOnValueChanged([this, borders](const int &newVal) {
-					borders[3] = (int)(newVal);
+				bottomborder->setOnValueChanged([borders](const int &newVal) {
+					borders[3] = (int)newVal;
 				});
 
 				bordersConfig->addWithLabel(_("LEFT BORDER"), leftborder);
@@ -833,9 +833,10 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				bordersConfig->addWithLabel(_("RIGHT BORDER"), rightborder);
 				bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
 
-				bordersConfig->addSaveFunc([this, ee_videomode, borders]
+				bordersConfig->addSaveFunc([ee_videomode, borders]
 				{
-					std::string result = borders[0]+" "+borders[1]+" "+borders[2]+" "+borders[3];
+					std::string result = to_string(borders[0])+" "+to_string(borders[1])+
+						" "+to_string(borders[2])+" "+to_string(borders[3]);
 					SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);
 					runSystemCommand("ee_set_borders "+result, "", nullptr);
 				});

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -899,17 +899,19 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions] {
 		std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
-		int* _borders = new int[4];
+		float _borders[4] = {0, 0, 0, 0};
+		char buffer[100];
+		sprintf(buffer, "%.0f %.0f %.0f %.0f", _borders[0], _borders[1], _borders[2], _borders[3]);
+		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 		if (!ee_borders.empty()) {
 			std::vector<int> savedBorders = int_explode(ee_borders, ' ');
 			if (savedBorders.size() == 4) {
 				for(int i=0; i < 4; ++i)
-					_borders[i] = savedBorders[i];
+					_borders[i] = (float) savedBorders[i];
 			}
-		} else {
-			for(int i=0; i < 4; ++i)
-				_borders[i] = 0;
 		}
+		sprintf(buffer, "%.0f %.0f %.0f %.0f", _borders[0], _borders[1], _borders[2], _borders[3]);
+		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
 		GuiSettings* bordersConfig = new GuiSettings(mWindow, _("FRAME BORDERS"));
 		if (ee_framebuffer.empty())
@@ -920,24 +922,24 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 		// borders
 		auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
-		leftborder->setValue((float)_borders[0]);
-		leftborder->setOnValueChanged([_borders](const float &newVal) {
-			_borders[0] = (int)Math::round(newVal);
+		leftborder->setValue(_borders[0]);
+		leftborder->setOnValueChanged([&_borders](const float &newVal) {
+			_borders[0] = Math::round(newVal);
 		});
 		auto topborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
-		topborder->setValue((float)_borders[1]);
-		topborder->setOnValueChanged([_borders](const float &newVal) {
-			_borders[1] = (int)Math::round(newVal);
+		topborder->setValue(_borders[1]);
+		topborder->setOnValueChanged([&_borders](const float &newVal) {
+			_borders[1] = Math::round(newVal);
 		});
 		auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
-		rightborder->setValue((float)_borders[2]);
-		rightborder->setOnValueChanged([_borders](const float &newVal) {
-			_borders[2] = (int)Math::round(newVal);
+		rightborder->setValue(_borders[2]);
+		rightborder->setOnValueChanged([&_borders](const float &newVal) {
+			_borders[2] = Math::round(newVal);
 		});
 		auto bottomborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
-		bottomborder->setValue((float)_borders[3]);
-		bottomborder->setOnValueChanged([_borders](const float &newVal) {
-			_borders[3] = (int)Math::round(newVal);
+		bottomborder->setValue(_borders[3]);
+		bottomborder->setOnValueChanged([&_borders](const float &newVal) {
+			_borders[3] = Math::round(newVal);
 		});
 
 		bordersConfig->addWithLabel(_("LEFT BORDER"), leftborder);
@@ -947,20 +949,23 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 		bordersConfig->addSaveFunc([ee_videomode, dimensions, &_borders]()
 		{
-			std::string result = std::to_string(_borders[0])+" "+
-				std::to_string(_borders[1])+" "+
-				std::to_string(_borders[2])+" "+
-				std::to_string(_borders[3]);
+			sprintf(buffer, "%.0f %.0f %.0f %.0f", _borders[0], _borders[1], _borders[2], _borders[3]);
+			mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
+			
+			std::string result = std::to_string((int)_borders[0])+" "+
+				std::to_string((int)_borders[1])+" "+
+				std::to_string((int)_borders[2])+" "+
+				std::to_string((int)_borders[3]);
 			SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);
 
-			result = std::to_string(_borders[0])+" "+
-				std::to_string(_borders[1])+" "+
-				std::to_string(dimensions[0]-_borders[2]-1)+" "+
-				std::to_string(dimensions[1]-_borders[3]-1);
+			result = std::to_string((int)_borders[0])+" "+
+				std::to_string((int)_borders[1])+" "+
+				std::to_string(dimensions[0]-((int)_borders[2])-1)+" "+
+				std::to_string(dimensions[1]-((int)_borders[3])-1);
 			
 			SystemConf::getInstance()->set(ee_videomode+".ee_offsets", result);
 			//runSystemCommand("ee_set_borders "+result, "", nullptr);
-			delete [] _borders;
+			//delete [] _borders;
 		});
 
 		mWindow->pushGui(bordersConfig);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -899,12 +899,12 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions] {
 		std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
-		int borders[4] = {0,0,0,0};
+		static int _borders[4] = {0,0,0,0};
 		if (!ee_borders.empty()) {
 			std::vector<int> savedBorders = int_explode(ee_borders, ' ');
 			if (savedBorders.size() == 4) {
 				for(int i=0; i < 4; ++i)
-					borders[i] = savedBorders[i];
+					_borders[i] = savedBorders[i];
 			}
 		}
 
@@ -917,24 +917,24 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 		// borders
 		auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
-		leftborder->setValue((float)borders[0]);
-		leftborder->setOnValueChanged([&](const float &newVal) {
-			borders[0] = (int)Math::round(newVal);
+		leftborder->setValue((float)_borders[0]);
+		leftborder->setOnValueChanged([&_borders](const float &newVal) {
+			_borders[0] = (int)Math::round(newVal);
 		});
 		auto topborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
-		topborder->setValue((float)borders[1]);
-		topborder->setOnValueChanged([&](const float &newVal) {
-			borders[1] = (int)Math::round(newVal);
+		topborder->setValue((float)_borders[1]);
+		topborder->setOnValueChanged([&_borders](const float &newVal) {
+			_borders[1] = (int)Math::round(newVal);
 		});
 		auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
-		rightborder->setValue((float)borders[2]);
-		rightborder->setOnValueChanged([&](const float &newVal) {
-			borders[2] = (int)Math::round(newVal);
+		rightborder->setValue((float)_borders[2]);
+		rightborder->setOnValueChanged([&_borders](const float &newVal) {
+			_borders[2] = (int)Math::round(newVal);
 		});
 		auto bottomborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
-		bottomborder->setValue((float)borders[3]);
-		bottomborder->setOnValueChanged([&](const float &newVal) {
-			borders[3] = (int)Math::round(newVal);
+		bottomborder->setValue((float)_borders[3]);
+		bottomborder->setOnValueChanged([&_borders](const float &newVal) {
+			_borders[3] = (int)Math::round(newVal);
 		});
 
 		bordersConfig->addWithLabel(_("LEFT BORDER"), leftborder);
@@ -942,21 +942,22 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		bordersConfig->addWithLabel(_("TOP BORDER"), topborder);
 		bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
 
-		bordersConfig->addSaveFunc([&]()
+		bordersConfig->addSaveFunc([ee_videomode, dimensions, &_borders]()
 		{
-			std::string result = std::to_string(borders[0])+" "+
-				std::to_string(borders[1])+" "+
-				std::to_string(borders[2])+" "+
-				std::to_string(borders[3]);
+			std::string result = std::to_string(_borders[0])+" "+
+				std::to_string(_borders[1])+" "+
+				std::to_string(_borders[2])+" "+
+				std::to_string(_borders[3]);
 			SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);
 
-			result = std::to_string(borders[0])+" "+
-				std::to_string(borders[1])+" "+
-				std::to_string(dimensions[0]-borders[2]-1)+" "+
-				std::to_string(dimensions[1]-borders[3]-1);
+			result = std::to_string(_borders[0])+" "+
+				std::to_string(_borders[1])+" "+
+				std::to_string(dimensions[0]-_borders[2]-1)+" "+
+				std::to_string(dimensions[1]-_borders[3]-1);
 			
 			SystemConf::getInstance()->set(ee_videomode+".ee_offsets", result);
-			//runSystemCommand("ee_set_borders "+result, "", nullptr);			
+			//runSystemCommand("ee_set_borders "+result, "", nullptr);
+			delete _borders;
 		});
 
 		mWindow->pushGui(bordersConfig);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -862,9 +862,11 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			
 			std::string ee_offsets = SystemConf::getInstance()->get(ee_videomode+".ee_offsets");
 
-			int pos = selectedFB.find(' ');
-			int width = atoi(selectedFB.substr(0, pos).c_str());
-			int height = atoi(selectedFB.substr(pos+1).c_str());
+			//int pos = selectedFB.find(' ');
+			//int width = atoi(selectedFB.substr(0, pos).c_str());
+			//int height = atoi(selectedFB.substr(pos+1).c_str());
+			int width = dimensions[0];
+			int height = dimensions[1];
 
 			std::string result = "0 0 "+
 				std::to_string(width-1)+" "+
@@ -940,21 +942,17 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 			saveBorders();
 
-			bool hasBorder = false;
-			for(int i=0; i < 4; ++i) {
-				if (borders[i] > 0) {
-					hasBorder=true;
-					break;
-				}
-			}
-			if (!hasBorder)
+			if (borders[0] == 0 && borders[1] == 0 && borders[2] == 0 && borders[3] == 0)
+			{
+				SystemConf::getInstance()->set(ee_videomode+".ee_offsets", "");
 				return;
+			}
 
 			std::string result = std::to_string(borders[0])+" "+
 				std::to_string(borders[1])+" "+
 				std::to_string(dimensions[0]-borders[2]-1)+" "+
 				std::to_string(dimensions[1]-borders[3]-1);
-
+			
 			SystemConf::getInstance()->set(ee_videomode+".ee_offsets", result);
 			runSystemCommand("ee_set_borders "+result, "", nullptr);			
 		});

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -903,23 +903,23 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		fbSave(emuelec_frame_buffer->getSelected());
 	});
 
-	std::string str_ee_offsets = SystemConf::getInstance()->get(ee_videomode+".ee_offsets");
-	
-	static float ee_borders[4] = {0.0,0.0,0.0,0.0};
-	memset(ee_borders, 0, 4*sizeof(*ee_borders));
 
-	if (!str_ee_offsets.empty()) {
-		std::vector<int> savedBorders = int_explode(str_ee_offsets, ' ');
-		if (savedBorders.size() == 4) {
-			for(int i=0; i < 4; ++i)
-				ee_borders[i] = (float) savedBorders[i];
-		}
-	}
-	buffer[100];
 	sprintf(buffer, "border: %.0f %.0f %.0f %.0f", ee_borders[0], ee_borders[1], ee_borders[2], ee_borders[3]);
 	mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
-	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, ee_dimensions, &ee_borders] {
+	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, ee_dimensions] {
+		std::string str_ee_offsets = SystemConf::getInstance()->get(ee_videomode+".ee_offsets");	
+		static float ee_borders[4] = {0.0,0.0,0.0,0.0};
+		//memset(ee_borders, 0, 4*sizeof(*ee_borders));
+
+		if (!str_ee_offsets.empty()) {
+			std::vector<int> savedBorders = int_explode(str_ee_offsets, ' ');
+			if (savedBorders.size() == 4) {
+				for(int i=0; i < 4; ++i)
+					ee_borders[i] = (float) savedBorders[i];
+			}
+		}
+		
 		char buffer[100];
 		sprintf(buffer, "border: %.0f %.0f %.0f %.0f", ee_borders[0], ee_borders[1], ee_borders[2], ee_borders[3]);
 		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -787,6 +787,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		dangerZone->addSaveFunc([mWindow, emuelec_frame_buffer, ee_videomode] {
 			if (emuelec_frame_buffer->changed()) {
 				std::string selectedFB = emuelec_frame_buffer->getSelected();
+				if (selectedFB == "auto")
+					return;
 
 				SystemConf::getInstance()->set(ee_videomode+".ee_framebuffer", selectedFB);
 				mWindow->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
@@ -843,9 +845,16 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			{
 				std::string result = std::to_string(borders[0])+" "+
 					std::to_string(borders[1])+" "+
+					std::to_string(borders[2])+" "+
+					std::to_string(borders[3]);
+				SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);
+
+				result = std::to_string(borders[0])+" "+
+					std::to_string(borders[1])+" "+
 					std::to_string(screenWidth-borders[2]-1)+" "+
 					std::to_string(screenHeight-borders[3]-1);
-				SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);
+
+				SystemConf::getInstance()->set(ee_videomode+".ee_offsets", result);
 				runSystemCommand("ee_set_borders "+result, "", nullptr);
 			});
 			mWindow->pushGui(bordersConfig);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -821,7 +821,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		ee_framebuffer = "auto";
 	}
 	std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
-	int* borders = {0,0,0,0}; 
+	int* borders;
 	if (!ee_borders.empty())
 		borders = &int_explode(ee_borders, ' ')[0]; 
 
@@ -886,7 +886,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			return;
 
 		auto saveBorders = [mWindow, ee_videomode, &borders]() {
-			mWindow->displayNotificationMessage(_U("\uF011  ") + "saveBorders"));
+			mWindow->displayNotificationMessage(_U("\uF011  ") + _("saveBorders"));
 			std::string result = std::to_string(borders[0])+" "+
 				std::to_string(borders[1])+" "+
 				std::to_string(borders[2])+" "+
@@ -930,7 +930,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 		bordersConfig->addSaveFunc([mWindow, ee_videomode, dimensions, borders]()
 		{
-			mWindow->displayNotificationMessage(_U("\uF011  ") + "bordersConfig->addSaveFunc"));
+			mWindow->displayNotificationMessage(_U("\uF011  ") + ("bordersConfig->addSaveFunc"));
 			bool hasBorder = false;
 			for(int i=0; i < 4; ++i) {
 				if (borders[i] > 0) {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -860,10 +860,6 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	ee_screen.width = ee_dimensions[0];
 	ee_screen.height = ee_dimensions[1];
 
-	char buffer[100];
-	sprintf(buffer, "dim: %d %d", ee_screen.width, ee_screen.height);
-	mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
-
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
 
 	emuelec_frame_buffer->add("auto", "auto", ee_framebuffer == "auto");
@@ -898,16 +894,10 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 	emuelec_frame_buffer->setSelectedChangedCallback([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, ee_screen](std::string name)
 	{
-		char buffer[100];
-		sprintf(buffer, "dim: %d %d", ee_screen.width, ee_screen.height);
-		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
-				
 		fbSave(emuelec_frame_buffer->getSelected());
 	});
 
 	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, ee_screen] {
-		char buffer[100];
-
 		static sScreenBorders ee_borders;
 		ee_borders.left = 0.0f;
 		ee_borders.right = 0.0f;
@@ -917,8 +907,6 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		std::string str_ee_offsets = SystemConf::getInstance()->get(ee_videomode+".ee_offsets");
 		if (!str_ee_offsets.empty()) {
 			std::vector<int> savedBorders = int_explode(str_ee_offsets, ' ');
-			sprintf(buffer, "size: %d", savedBorders.size());
-			mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));			
 			if (savedBorders.size() == 4) {
 				ee_borders.left = (float) savedBorders[0];
 				ee_borders.top = (float) savedBorders[1];
@@ -926,12 +914,6 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				ee_borders.bottom = (float) savedBorders[3];
 			}
 		}
-
-		sprintf(buffer, "border: %.0f %.0f %.0f %.0f", ee_borders.left, ee_borders.top, ee_borders.right, ee_borders.bottom);
-		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
-
-		sprintf(buffer, "dimensions: %d %d", ee_screen.width, ee_screen.height);
-		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
 		GuiSettings* bordersConfig = new GuiSettings(mWindow, _("FRAME BORDERS"));
 		if (ee_framebuffer.empty())
@@ -943,24 +925,15 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		// borders
 		auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
 		leftborder->setValue(ee_borders.left);
-		leftborder->setOnValueChanged([](const float &newVal) {
-			//ee_borders[0] = Math::round(newVal);
-		});
+
 		auto topborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
 		topborder->setValue(ee_borders.top);
-		topborder->setOnValueChanged([](const float &newVal) {
-			//ee_borders[1] = Math::round(newVal);
-		});
+
 		auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
 		rightborder->setValue((ee_borders.right > 0.0f) ? width-ee_borders.right-1 : 0.0f);
-		rightborder->setOnValueChanged([](const float &newVal) {
-			//ee_borders[2] = Math::round(newVal);
-		});
+
 		auto bottomborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
 		bottomborder->setValue((ee_borders.bottom > 0.0f) ? height-ee_borders.bottom-1 : 0.0f);
-		bottomborder->setOnValueChanged([](const float &newVal) {
-			//ee_borders[3] = Math::round(newVal);
-		});
 
 		bordersConfig->addWithLabel(_("LEFT BORDER"), leftborder);
 		bordersConfig->addWithLabel(_("RIGHT BORDER"), rightborder);
@@ -975,20 +948,13 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			borders[2] = (int) rightborder->getValue();
 			borders[3] = (int) bottomborder->getValue();
 
-			char buffer[100];
-			sprintf(buffer, "border: %d %d %d %d", borders[0], borders[1], borders[2], borders[3]);
-			mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
-
-			sprintf(buffer, "dim: %d %d", ee_screen.width, ee_screen.height);
-			mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
-			
 			std::string result = std::to_string(borders[0])+" "+
 				std::to_string(borders[1])+" "+
 				std::to_string(ee_screen.width-(borders[2])-1)+" "+
 				std::to_string(ee_screen.height-(borders[3])-1);
 
 			SystemConf::getInstance()->set(ee_videomode+".ee_offsets", result);
-			runSystemCommand("ee_setborders "+result, "", nullptr);
+			runSystemCommand("ee_set_borders "+result, "", nullptr);
 		});
 
 		mWindow->pushGui(bordersConfig);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -854,7 +854,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		reslist.push_back("800 600");
 		reslist.push_back("640 480");
 
-	ee_dimensions = getVideoModeDimensions(ee_videomode, reslist);
+	static auto ee_dimensions = getVideoModeDimensions(ee_videomode, reslist);
 
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
 
@@ -896,6 +896,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	});
 
 	std::string str_ee_offsets = SystemConf::getInstance()->get(ee_videomode+".ee_offsets");
+	
+	static float[4] ee_borders = {0.0,0.0,0.0,0.0};
 	memset(ee_borders, 0, 4*sizeof(*ee_borders));
 
 	char buffer[100];

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -777,17 +777,17 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			emuelec_frame_buffer->add(*it, *it, ee_framebuffer == *it); }
 		dangerZone->addWithLabel(_("FRAME BUFFER"), emuelec_frame_buffer);
 	   	
-		dangerZone->addSaveFunc([mWindow, emuelec_frame_buffer, ee_videomode, screenWidth, screenHeight] {
+		dangerZone->addSaveFunc([mWindow, emuelec_frame_buffer, ee_videomode] {
 			if (emuelec_frame_buffer->changed()) {
 				std::string selectedFB = emuelec_frame_buffer->getSelected();
 				int pos = selectedFB.find('x');
-				screenWidth = atoi(selectedFB.substr(0, pos).c_str());
-				screenHeight = atoi(selectedFB.substr(pos+1).c_str());
+				int screenWidth = atoi(selectedFB.substr(0, pos).c_str());
+				int screenHeight = atoi(selectedFB.substr(pos+1).c_str());
 
 				std::string ee_videomode = SystemConf::getInstance()->get("ee_videomode");
 				SystemConf::getInstance()->set(ee_videomode+".ee_framebuffer", screenWidth+" "+screenHeight);
+				mWindow->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
 			}
-			mWindow->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
 		});
 
 		if (!ee_framebuffer.empty() && ee_framebuffer != "auto") {
@@ -807,24 +807,24 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		    }
 
 				// borders
-				auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.f, float(screenWidth)/2, 1.f, "px");
+				auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.f, float(screenWidth)/2.0f, 1.f, "px");
 				leftborder->setValue((float)borders[0]);
-				leftborder->setOnValueChanged([borders](const float &newVal) {
+				leftborder->setOnValueChanged([this, borders](const float &newVal) {
 					borders[0] = (int)Math::round(newVal);
 				});
-				auto topborder = std::make_shared<SliderComponent>(mWindow, 0.f, float(screenHeight)/2, 1.f, "px");
+				auto topborder = std::make_shared<SliderComponent>(mWindow, 0.f, float(screenHeight)/2.0f, 1.f, "px");
 				topborder->setValue((float)borders[1]);
-				topborder->setOnValueChanged([borders](const float &newVal) {
+				topborder->setOnValueChanged([this, borders](const float &newVal) {
 					borders[1] = (int)Math::round(newVal);
 				});
-				auto rightborder = std::make_shared<SliderComponent>(mWindow, float(screenWidth)-1, float(screenWidth)/2, -1.f, "px");
+				auto rightborder = std::make_shared<SliderComponent>(mWindow, float(screenWidth)-1.0f, float(screenWidth)/2.0f, -1.f, "px");
 				rightborder->setValue((float)borders[2]);
-				rightborder->setOnValueChanged([borders](const float &newVal) {
+				rightborder->setOnValueChanged([this, borders](const float &newVal) {
 					borders[2] = (int)Math::round(newVal);
 				});
-				auto bottomborder = std::make_shared<SliderComponent>(mWindow, float(screenHeight)-1, float(screenHeight)/2, -1.f, "px");
+				auto bottomborder = std::make_shared<SliderComponent>(mWindow, float(screenHeight)-1.0f, float(screenHeight)/2.0f, -1.f, "px");
 				bottomborder->setValue((float)borders[3]);
-				bottomborder->setOnValueChanged([borders](const float &newVal) {
+				bottomborder->setOnValueChanged([this, borders](const float &newVal) {
 					borders[3] = (int)Math::round(newVal);
 				});
 
@@ -833,7 +833,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				bordersConfig->addWithLabel(_("RIGHT BORDER"), rightborder);
 				bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
 
-				bordersConfig->addSaveFunc([ee_videomode, borders]
+				bordersConfig->addSaveFunc([this, ee_videomode, borders]
 				{
 					std::string result = borders[0]+" "+borders[1]+" "+borders[2]+" "+borders[3];
 					SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -809,22 +809,22 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				// borders
 				auto leftborder = std::make_shared<SliderComponent>(mWindow, 0, int(screenWidth)/2, 1, "px");
 				leftborder->setValue((int)borders[0]);
-				leftborder->setOnValueChanged([borders](const float &newVal) {
+				leftborder->setOnValueChanged([&borders](const float &newVal) {
 					borders[0] = (int)Math::round(newVal);
 				});
 				auto topborder = std::make_shared<SliderComponent>(mWindow, 0, int(screenHeight)/2, 1, "px");
 				topborder->setValue((int)borders[1]);
-				topborder->setOnValueChanged([borders](const float &newVal) {
+				topborder->setOnValueChanged([&borders](const float &newVal) {
 					borders[1] = (int)Math::round(newVal);
 				});
 				auto rightborder = std::make_shared<SliderComponent>(mWindow, int(screenWidth)-1, int(screenWidth)/2, -1, "px");
 				rightborder->setValue((int)borders[2]);
-				rightborder->setOnValueChanged([borders](const float &newVal) {
+				rightborder->setOnValueChanged([&borders](const float &newVal) {
 					borders[2] = (int)Math::round(newVal);
 				});
 				auto bottomborder = std::make_shared<SliderComponent>(mWindow, int(screenHeight)-1, int(screenHeight)/2, -1, "px");
 				bottomborder->setValue((int)borders[3]);
-				bottomborder->setOnValueChanged([borders](const float &newVal) {
+				bottomborder->setOnValueChanged([&borders](const float &newVal) {
 					borders[3] = (int)Math::round(newVal);
 				});
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -757,7 +757,10 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		screenWidth = atoi(ee_framebuffer.substr(0, pos).c_str());
 		screenHeight = atoi(ee_framebuffer.substr(pos+1).c_str());
 	}
-
+	else {
+		ee_framebuffer = "auto";
+	}
+	
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
         std::vector<std::string> framebuffer;
 		framebuffer.push_back("3840x2160");
@@ -768,8 +771,6 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		framebuffer.push_back("1024x768");
 		framebuffer.push_back("800x600");
 		framebuffer.push_back("640x480");
-		if (ee_framebuffer.empty())
-			ee_framebuffer = "auto";
 
 		emuelec_frame_buffer->add("auto", "auto", ee_framebuffer == "auto");
 		for (auto it = framebuffer.cbegin(); it != framebuffer.cend(); it++) {
@@ -777,12 +778,15 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		}
 		dangerZone->addWithLabel(_("FRAME BUFFER"), emuelec_frame_buffer);
 
+		emuelec_frame_buffer->setSelectedChangedCallback([mWindow, ee_videomode](std::string name)
+		{
+			SystemConf::getInstance()->set(ee_videomode+".ee_framebuffer", name);
+			mWindow->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
+		});
+
 		dangerZone->addSaveFunc([mWindow, emuelec_frame_buffer, ee_videomode] {
 			if (emuelec_frame_buffer->changed()) {
 				std::string selectedFB = emuelec_frame_buffer->getSelected();
-				//int pos = selectedFB.find('x');
-				//int screenWidth = atoi(selectedFB.substr(0, pos).c_str());
-				//int screenHeight = atoi(selectedFB.substr(pos+1).c_str());
 
 				SystemConf::getInstance()->set(ee_videomode+".ee_framebuffer", selectedFB);
 				mWindow->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
@@ -813,13 +817,11 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			leftborder->setValue((float)borders[0]);
 			leftborder->setOnValueChanged([&borders](const float &newVal) {
 				borders[0] = (int)Math::round(newVal);
-				//rightborder->setValue((float)borders[0]);
 			});
 			auto topborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenHeight)/2.0f, 1.0f, "px");
 			topborder->setValue((float)borders[1]);
 			topborder->setOnValueChanged([&borders](const float &newVal) {
 				borders[1] = (int)Math::round(newVal);
-				//bottomborder->setValue((float)borders[1]);
 			});
 			auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenWidth)/2.0f, 1.0f, "px");
 			rightborder->setValue((float)borders[2]);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -953,7 +953,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		bordersConfig->addWithLabel(_("TOP BORDER"), topborder);
 		bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
 
-		bordersConfig->addSaveFunc([mWindow, ee_videomode, ee_dimensions]()
+		bordersConfig->addSaveFunc([mWindow, ee_videomode, ee_dimensions, leftborder,rightborder,topborder,bottomborder]()
 		{
 			float borders[4] = {0.0,0.0,0.0,0.0};
 			borders[0] = leftborder->getValue();

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -147,10 +147,19 @@ static std::string toupper(std::string s)
 static int* getVideoModeDimensions(std::string ee_videomode, std::vector<std::string> reslist) 
 {
 	static int screen[2] = {0, 0};
+	int pos = 0;
 	if (pos = ee_videomode.find('x'))
 	{
 		screen[0] = atoi(ee_videomode.substr(0, pos).c_str());
-		screen[1] = atoi(ee_videomode.substr(pos+1).c_str());					
+		std::string tmp = ee_videomode.substr(pos+1);
+		if (pos = tmp.find('p'))
+		{
+			screen[1] = atoi(tmp.substr(0, pos).c_str());					
+		}
+		else if (pos = tmp.find('i'))
+		{
+			screen[1] = atoi(tmp.substr(0, pos).c_str());					
+		}					
 	}
 	else if (pos = ee_videomode.find('p'))
 	{
@@ -837,7 +846,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	else {
 		ee_framebuffer = "auto";
 	}
-	
+
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
 
 	emuelec_frame_buffer->add("auto", "auto", ee_framebuffer == "auto");
@@ -846,7 +855,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	}
 	dangerZone->addWithLabel(_("FRAME BUFFER"), emuelec_frame_buffer);
 
-	auto fbSave = [mWindow, emuelec_frame_buffer, ee_videomode, dimensions](std::string selectedFB) {
+	auto fbSave = [mWindow, emuelec_frame_buffer, ee_videomode, dimensions] (std::string selectedFB) {
 		if (emuelec_frame_buffer->changed()) {
 			if (selectedFB == "auto")
 				selectedFB = "";
@@ -875,7 +884,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		fbSave(name);
 	});
 
-	dangerZone->addSaveFunc([mWindow, emuelec_frame_buffer, ee_videomode, dimensions]
+	dangerZone->addSaveFunc([mWindow, emuelec_frame_buffer, ee_videomode, dimensions]()
+	{
 		fbSave(emuelec_frame_buffer->getSelected());
 	});
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -856,6 +856,10 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 	int* ee_dimensions = getVideoModeDimensions(ee_videomode, reslist);
 
+	sScreenDimenions ee_screen;
+	ee_screen.width = ee_dimensions[0];
+	ee_screen.height = ee_dimensions[1];
+
 	/*std::shared_ptr<int> ee_dimensions (new int [2], [](int* d){
 		 delete [] d;
 	});
@@ -877,7 +881,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	}
 	dangerZone->addWithLabel(_("FRAME BUFFER"), emuelec_frame_buffer);
 
-	auto fbSave = [mWindow, emuelec_frame_buffer, ee_videomode, ee_dimensions] (std::string selectedFB) {
+	auto fbSave = [mWindow, emuelec_frame_buffer, ee_videomode, ee_screen] (std::string selectedFB) {
 		if (emuelec_frame_buffer->changed()) {
 			if (selectedFB == "auto")
 				selectedFB = "";
@@ -889,22 +893,19 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				SystemConf::getInstance()->set(ee_videomode+".ee_offsets", "");
 				return;
 			}
-			
-			int width = ee_dimensions[0];
-			int height = ee_dimensions[1];
 
 			std::string result = "0 0 "+
-				std::to_string(width-1)+" "+
-				std::to_string(height-1);
+				std::to_string(ee_screen.width-1)+" "+
+				std::to_string(ee_screen.height-1);
 
 			SystemConf::getInstance()->set(ee_videomode+".ee_offsets", result);
 		}
 	};
 
-	emuelec_frame_buffer->setSelectedChangedCallback([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, ee_dimensions](std::string name)
+	emuelec_frame_buffer->setSelectedChangedCallback([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, ee_screen](std::string name)
 	{
 		char buffer[100];
-		sprintf(buffer, "dim: %d %d", ee_dimensions[0], ee_dimensions[1]);
+		sprintf(buffer, "dim: %d %d", ee_screen.width, ee_screen.height);
 		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 				
 		fbSave(emuelec_frame_buffer->getSelected());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -904,8 +904,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	});
 
 
-	sprintf(buffer, "border: %.0f %.0f %.0f %.0f", ee_borders[0], ee_borders[1], ee_borders[2], ee_borders[3]);
-	mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
+	//sprintf(buffer, "border: %.0f %.0f %.0f %.0f", ee_borders[0], ee_borders[1], ee_borders[2], ee_borders[3]);
+	//mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
 	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, ee_dimensions] {
 		std::string str_ee_offsets = SystemConf::getInstance()->get(ee_videomode+".ee_offsets");	

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -870,7 +870,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	}
 	dangerZone->addWithLabel(_("FRAME BUFFER"), emuelec_frame_buffer);
 
-	auto fbSave = [mWindow, emuelec_frame_buffer, ee_videomode, ee_dimensions] (std::string selectedFB) {
+	auto fbSave = [mWindow, emuelec_frame_buffer, ee_videomode, &ee_dimensions] (std::string selectedFB) {
 		if (emuelec_frame_buffer->changed()) {
 			if (selectedFB == "auto")
 				selectedFB = "";
@@ -894,7 +894,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		}
 	};
 
-	emuelec_frame_buffer->setSelectedChangedCallback([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, ee_dimensions](std::string name)
+	emuelec_frame_buffer->setSelectedChangedCallback([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, &ee_dimensions](std::string name)
 	{
 		char buffer[100];
 		sprintf(buffer, "dim: %d %d", ee_dimensions[0], ee_dimensions[1]);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -144,9 +144,9 @@ static std::string toupper(std::string s)
 	return s;
 }
 
-int* getVideoModeDimensions(std::string videomode, std::vector<std::string> reslist) 
+std::array<int,2> getVideoModeDimensions(std::string videomode, std::vector<std::string> reslist) 
 {
-	static int screen[2] = {0, 0};
+	std::array<int,2> screen;
 
 	if (videomode == "480cvbs")
 	{
@@ -854,7 +854,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		reslist.push_back("800 600");
 		reslist.push_back("640 480");
 
-	int* dimensions = getVideoModeDimensions(ee_videomode, reslist);
+	std::array<int,2> dimensions = getVideoModeDimensions(ee_videomode, reslist);
 
 	std::shared_ptr<int> ee_dimensions (new int [2], [](int* d){
 		 delete [] d;

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -144,7 +144,7 @@ static std::string toupper(std::string s)
 	return s;
 }
 
-int* getVideoModeDimensions(std::string ee_videomode, std::vector<std::string> reslist) 
+static void getVideoModeDimensions(std::string ee_videomode, std::vector<std::string> reslist) 
 {
 	int screen[2] = {0, 0};
 	
@@ -187,7 +187,8 @@ int* getVideoModeDimensions(std::string ee_videomode, std::vector<std::string> r
 			}
 		}
 	}	
-	return screen;
+	ee_dimensions[0] = screen[0];
+	ee_dimensions[1] = screen[1];
 }
 
 #endif
@@ -854,7 +855,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		reslist.push_back("800 600");
 		reslist.push_back("640 480");
 
-	ee_dimensions = getVideoModeDimensions(ee_videomode, reslist);
+	getVideoModeDimensions(ee_videomode, reslist);
 
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
 
@@ -866,7 +867,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	}
 	dangerZone->addWithLabel(_("FRAME BUFFER"), emuelec_frame_buffer);
 
-	auto fbSave = [mWindow, emuelec_frame_buffer, ee_videomode, dimensions] (std::string selectedFB) {
+	auto fbSave = [mWindow, emuelec_frame_buffer, ee_videomode, &ee_dimensions] (std::string selectedFB) {
 		if (emuelec_frame_buffer->changed()) {
 			if (selectedFB == "auto")
 				selectedFB = "";
@@ -879,8 +880,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				return;
 			}
 			
-			int width = dimensions[0];
-			int height = dimensions[1];
+			int width = ee_dimensions[0];
+			int height = ee_dimensions[1];
 
 			std::string result = "0 0 "+
 				std::to_string(width-1)+" "+
@@ -963,7 +964,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				std::to_string((int)ee_borders[3]);
 			SystemConf::getInstance()->set(ee_videomode+".eeee_borders", result);*/
 
-			result = std::to_string((int)ee_borders[0])+" "+
+			std::string result = std::to_string((int)ee_borders[0])+" "+
 				std::to_string((int)ee_borders[1])+" "+
 				std::to_string(ee_dimensions[0]-((int)ee_borders[2])-1)+" "+
 				std::to_string(ee_dimensions[1]-((int)ee_borders[3])-1);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -825,7 +825,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	int borders[4] = {0, 0, 0, 0};
 	if (!ee_borders.empty()) {
 		std::vector<int> savedBorders = int_explode(ee_borders, ' ');
-		if (savedBorders && savedBorders.size() == 4) {
+		if (savedBorders.size() == 4) {
 			for(int i=0; i < 4; ++i)
 				borders[i] = savedBorders[i];
 		}

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -895,17 +895,19 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		fbSave(emuelec_frame_buffer->getSelected());
 	});
 
-	std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
-	int borders[4] = {0,0,0,0};
-	if (!ee_borders.empty()) {
-		std::vector<int> savedBorders = int_explode(ee_borders, ' ');
-		if (savedBorders.size() == 4) {
-			for(int i=0; i < 4; ++i)
-				borders[i] = savedBorders[i];
-		}
-	}
 
-	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions, &borders] {
+
+	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions] {
+		std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
+		int borders[4] = {0,0,0,0};
+		if (!ee_borders.empty()) {
+			std::vector<int> savedBorders = int_explode(ee_borders, ' ');
+			if (savedBorders.size() == 4) {
+				for(int i=0; i < 4; ++i)
+					borders[i] = savedBorders[i];
+			}
+		}
+
 		GuiSettings* bordersConfig = new GuiSettings(mWindow, _("FRAME BORDERS"));
 		if (ee_framebuffer.empty())
 			return;
@@ -916,22 +918,22 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		// borders
 		auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
 		leftborder->setValue((float)borders[0]);
-		leftborder->setOnValueChanged([borders](const float &newVal) {
+		leftborder->setOnValueChanged([&](const float &newVal) {
 			borders[0] = (int)Math::round(newVal);
 		});
 		auto topborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
 		topborder->setValue((float)borders[1]);
-		topborder->setOnValueChanged([borders](const float &newVal) {
+		topborder->setOnValueChanged([&](const float &newVal) {
 			borders[1] = (int)Math::round(newVal);
 		});
 		auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
 		rightborder->setValue((float)borders[2]);
-		rightborder->setOnValueChanged([borders](const float &newVal) {
+		rightborder->setOnValueChanged([&](const float &newVal) {
 			borders[2] = (int)Math::round(newVal);
 		});
 		auto bottomborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
 		bottomborder->setValue((float)borders[3]);
-		bottomborder->setOnValueChanged([borders](const float &newVal) {
+		bottomborder->setOnValueChanged([&](const float &newVal) {
 			borders[3] = (int)Math::round(newVal);
 		});
 
@@ -940,7 +942,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		bordersConfig->addWithLabel(_("TOP BORDER"), topborder);
 		bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
 
-		bordersConfig->addSaveFunc([mWindow, saveBorders, ee_videomode, dimensions, borders]()
+		bordersConfig->addSaveFunc([&]()
 		{
 			std::string result = std::to_string(borders[0])+" "+
 				std::to_string(borders[1])+" "+

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -866,7 +866,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	}
 	dangerZone->addWithLabel(_("FRAME BUFFER"), emuelec_frame_buffer);
 
-	auto fbSave = [mWindow, emuelec_frame_buffer, ee_videomode, &ee_dimensions] (std::string selectedFB) {
+	auto fbSave = [mWindow, emuelec_frame_buffer, ee_videomode, ee_dimensions] (std::string selectedFB) {
 		if (emuelec_frame_buffer->changed()) {
 			if (selectedFB == "auto")
 				selectedFB = "";

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -864,8 +864,6 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	sprintf(buffer, "dim: %d %d", ee_screen.width, ee_screen.height);
 	mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
-	std::string str_ee_offsets = SystemConf::getInstance()->get(ee_videomode+".ee_offsets");
-
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
 
 	emuelec_frame_buffer->add("auto", "auto", ee_framebuffer == "auto");
@@ -908,12 +906,14 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	});
 
 	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, ee_screen] {
+
 		static sScreenBorders ee_borders;
 		ee_borders.left = 0.0f;
 		ee_borders.right = 0.0f;
 		ee_borders.top = 0.0f;
 		ee_borders.bottom = 0.0f;
 
+		std::string str_ee_offsets = SystemConf::getInstance()->get(ee_videomode+".ee_offsets");
 		if (!str_ee_offsets.empty()) {
 			std::vector<int> savedBorders = int_explode(str_ee_offsets, ' ');
 			if (savedBorders.size() == 4) {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -148,33 +148,29 @@ static int* getVideoModeDimensions(std::string ee_videomode, std::vector<std::st
 {
 	static int screen[2] = {0, 0};
 	int pos = 0;
+	std::string tmp;
 	if (pos = ee_videomode.find('x'))
 	{
 		screen[0] = atoi(ee_videomode.substr(0, pos).c_str());
-		std::string tmp = ee_videomode.substr(pos+1);
-		if (pos = tmp.find('p'))
-		{
-			screen[1] = atoi(tmp.substr(0, pos).c_str());					
-		}
-		else if (pos = tmp.find('i'))
-		{
-			screen[1] = atoi(tmp.substr(0, pos).c_str());					
-		}					
+		tmp = ee_videomode.substr(pos+1);
 	}
-	else if (pos = ee_videomode.find('p'))
+	else
+		tmp = ee_videomode;
+		
+	if (pos = tmp.find('p'))
 	{
-		screen[0] = atoi(ee_videomode.substr(0, pos).c_str());					
+		screen[1] = atoi(tmp.substr(0, pos).c_str());					
 	}
-	else if (pos = ee_videomode.find('i'))
+	else if (pos = tmp.find('i'))
 	{
-		screen[0] = atoi(ee_videomode.substr(0, pos).c_str());					
+		screen[1] = atoi(tmp.substr(0, pos).c_str());					
 	}
 	
-	if (screen[1] == 0) {
+	if (screen[0] == 0) {
 		for (auto it = reslist.cbegin(); it != reslist.cend(); it++) {
-			int pos = (*it).find("x"+std::tostring(screen[0]));
+			int pos = (*it).find("x"+std::to_string(screen[0]));
 			if (pos >= 0) {
-				screen[1] = atoi(ee_videomode.substr(0,pos).c_str());
+				screen[0] = atoi(ee_videomode.substr(0,pos).c_str());
 				break;
 			}
 		}
@@ -865,13 +861,12 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			
 			if (selectedFB == "")
 				return;
-			if 
 			
 			std::string ee_offsets = SystemConf::getInstance()->get(ee_videomode+".ee_offsets");
 			if (ee_offsets.empty())
 				return;
 
-			result = "0 0 "+
+			std::string result = "0 0 "+
 				std::to_string(dimensions[0]-1)+" "+
 				std::to_string(dimensions[1]-1);
 
@@ -879,12 +874,12 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		}
 	};
 
-	emuelec_frame_buffer->setSelectedChangedCallback([mWindow, emuelec_frame_buffer, ee_videomode, dimensions](std::string name)
+	emuelec_frame_buffer->setSelectedChangedCallback([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, dimensions](std::string name)
 	{
 		fbSave(name);
 	});
 
-	dangerZone->addSaveFunc([mWindow, emuelec_frame_buffer, ee_videomode, dimensions]()
+	dangerZone->addSaveFunc([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, dimensions]()
 	{
 		fbSave(emuelec_frame_buffer->getSelected());
 	});
@@ -902,22 +897,22 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			borders[i] = atoi(tmpBorders.c_str());
 
 		// borders
-		auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenWidth)/2.0f, 1.0f, "px");
+		auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(dimensions[0])/2.0f, 1.0f, "px");
 		leftborder->setValue((float)borders[0]);
 		leftborder->setOnValueChanged([&borders](const float &newVal) {
 			borders[0] = (int)Math::round(newVal);
 		});
-		auto topborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenHeight)/2.0f, 1.0f, "px");
+		auto topborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(dimensions[1])/2.0f, 1.0f, "px");
 		topborder->setValue((float)borders[1]);
 		topborder->setOnValueChanged([&borders](const float &newVal) {
 			borders[1] = (int)Math::round(newVal);
 		});
-		auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenWidth)/2.0f, 1.0f, "px");
+		auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(dimensions[0])/2.0f, 1.0f, "px");
 		rightborder->setValue((float)borders[2]);
 		rightborder->setOnValueChanged([&borders](const float &newVal) {
 			borders[2] = (int)Math::round(newVal);
 		});
-		auto bottomborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenHeight)/2.0f, 1.0f, "px");
+		auto bottomborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(dimensions[1])/2.0f, 1.0f, "px");
 		bottomborder->setValue((float)borders[3]);
 		bottomborder->setOnValueChanged([&borders](const float &newVal) {
 			borders[3] = (int)Math::round(newVal);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -144,7 +144,7 @@ static std::string toupper(std::string s)
 	return s;
 }
 
-static void getVideoModeDimensions(std::string ee_videomode, std::vector<std::string> reslist) 
+static int* getVideoModeDimensions(std::string ee_videomode, std::vector<std::string> reslist) 
 {
 	int screen[2] = {0, 0};
 	
@@ -187,8 +187,9 @@ static void getVideoModeDimensions(std::string ee_videomode, std::vector<std::st
 			}
 		}
 	}	
-	ee_dimensions[0] = screen[0];
-	ee_dimensions[1] = screen[1];
+	//ee_dimensions[0] = screen[0];
+	//ee_dimensions[1] = screen[1];
+	return screen;
 }
 
 #endif
@@ -855,7 +856,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		reslist.push_back("800 600");
 		reslist.push_back("640 480");
 
-	getVideoModeDimensions(ee_videomode, reslist);
+	ee_dimensions = getVideoModeDimensions(ee_videomode, reslist);
 
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
 
@@ -891,7 +892,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		}
 	};
 
-	emuelec_frame_buffer->setSelectedChangedCallback([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, dimensions](std::string name)
+	emuelec_frame_buffer->setSelectedChangedCallback([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, ee_dimensions](std::string name)
 	{
 		fbSave(emuelec_frame_buffer->getSelected());
 	});
@@ -913,7 +914,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	sprintf(buffer, "%.0f %.0f %.0f %.0f", ee_borders[0], ee_borders[1], ee_borders[2], ee_borders[3]);
 	mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
-	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, &ee_dimensions, &ee_borders] {
+	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, ee_dimensions, &ee_borders] {
 		char buffer[100];
 		sprintf(buffer, "%.0f %.0f %.0f %.0f", ee_borders[0], ee_borders[1], ee_borders[2], ee_borders[3]);
 		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
@@ -952,7 +953,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		bordersConfig->addWithLabel(_("TOP BORDER"), topborder);
 		bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
 
-		bordersConfig->addSaveFunc([mWindow, ee_videomode, &ee_dimensions, &ee_borders]()
+		bordersConfig->addSaveFunc([mWindow, ee_videomode, ee_dimensions, &ee_borders]()
 		{
 			char buffer[100];
 			sprintf(buffer, "%.0f %.0f %.0f %.0f", ee_borders[0], ee_borders[1], ee_borders[2], ee_borders[3]);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -892,12 +892,12 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		if (ee_framebuffer.empty())
 			return;
 
-		auto saveBorders = [mWindow, ee_videomode, &borders]() {
-			//mWindow->displayNotificationMessage(_U("\uF011  ") + _("saveBorders"));
-			std::string result = std::to_string(borders[0])+" "+
-				std::to_string(borders[1])+" "+
-				std::to_string(borders[2])+" "+
-				std::to_string(borders[3]);
+		auto saveBorders = [mWindow, ee_videomode](int[] b) {
+			mWindow->displayNotificationMessage(_U("\uF011  ") + _("saveBorders"));
+			std::string result = std::to_string(b[0])+" "+
+				std::to_string(b[1])+" "+
+				std::to_string(b[2])+" "+
+				std::to_string(b[3]);
 			SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);
 		};
 			
@@ -907,27 +907,23 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		// borders
 		auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
 		leftborder->setValue((float)borders[0]);
-		leftborder->setOnValueChanged([&borders, saveBorders](const float &newVal) {
+		leftborder->setOnValueChanged([&borders](const float &newVal) {
 			borders[0] = (int)Math::round(newVal);
-			saveBorders();
 		});
 		auto topborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
 		topborder->setValue((float)borders[1]);
-		topborder->setOnValueChanged([&borders, saveBorders](const float &newVal) {
+		topborder->setOnValueChanged([&borders](const float &newVal) {
 			borders[1] = (int)Math::round(newVal);
-			saveBorders();
 		});
 		auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
 		rightborder->setValue((float)borders[2]);
-		rightborder->setOnValueChanged([&borders, saveBorders](const float &newVal) {
+		rightborder->setOnValueChanged([&borders](const float &newVal) {
 			borders[2] = (int)Math::round(newVal);
-			saveBorders();
 		});
 		auto bottomborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
 		bottomborder->setValue((float)borders[3]);
-		bottomborder->setOnValueChanged([&borders, saveBorders](const float &newVal) {
+		bottomborder->setOnValueChanged([&borders](const float &newVal) {
 			borders[3] = (int)Math::round(newVal);
-			saveBorders();
 		});
 
 		bordersConfig->addWithLabel(_("LEFT BORDER"), leftborder);
@@ -938,6 +934,9 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		bordersConfig->addSaveFunc([mWindow, ee_videomode, dimensions, &borders]()
 		{
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _("bordersConfig->addSaveFunc"));
+			
+			saveBorders(borders);
+
 			bool hasBorder = false;
 			for(int i=0; i < 4; ++i) {
 				if (borders[i] > 0) {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -857,7 +857,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	auto ee_dimensions = std::make_shared<int*>(getVideoModeDimensions(ee_videomode, reslist));
 
 	char buffer[100];
-	sprintf(buffer, "dimensions: %.0f %.0f", *ee_dimensions[0], *ee_dimensions[1]);
+	sprintf(buffer, "dimensions: %.0f %.0f", **ee_dimensions[0], **ee_dimensions[1]);
 	mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -892,6 +892,10 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 	emuelec_frame_buffer->setSelectedChangedCallback([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, ee_dimensions](std::string name)
 	{
+		char buffer[100];
+		sprintf(buffer, "dim: %.0f %.0f", ee_dimensions[0], ee_dimensions[1]);
+		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
+				
 		fbSave(emuelec_frame_buffer->getSelected());
 	});
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -146,7 +146,7 @@ static std::string toupper(std::string s)
 
 int* getVideoModeDimensions(std::string videomode, std::vector<std::string> reslist) 
 {
-	static int[2] screen();
+	static int[2] screen;
 
 	if (videomode == "480cvbs")
 	{

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -928,7 +928,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		sprintf(buffer, "border: %.0f %.0f %.0f %.0f", ee_borders.left, ee_borders.top, ee_borders.right, ee_borders.bottom);
 		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
-		sprintf(buffer, "dimensions: %.0f %.0f", ee_screen.width, ee_screen.height);
+		sprintf(buffer, "dimensions: %d %d", ee_screen.width, ee_screen.height);
 		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
 		GuiSettings* bordersConfig = new GuiSettings(mWindow, _("FRAME BORDERS"));
@@ -950,12 +950,12 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			//ee_borders[1] = Math::round(newVal);
 		});
 		auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
-		rightborder->setValue((ee_borders.right > 0.0f) ? width-ee_borders.right+1 : 0.0f);
+		rightborder->setValue((ee_borders.right > 0.0f) ? width-ee_borders.right-1 : 0.0f);
 		rightborder->setOnValueChanged([](const float &newVal) {
 			//ee_borders[2] = Math::round(newVal);
 		});
 		auto bottomborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
-		bottomborder->setValue((ee_borders.top > 0.0f) ? height-ee_borders.top+1 : 0.0f);
+		bottomborder->setValue((ee_borders.top > 0.0f) ? height-ee_borders.top-1 : 0.0f);
 		bottomborder->setOnValueChanged([](const float &newVal) {
 			//ee_borders[3] = Math::round(newVal);
 		});
@@ -965,7 +965,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		bordersConfig->addWithLabel(_("TOP BORDER"), topborder);
 		bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
 
-		/*bordersConfig->addSaveFunc([mWindow, ee_videomode, ee_screen, leftborder,rightborder,topborder,bottomborder]()
+		bordersConfig->addSaveFunc([mWindow, ee_videomode, ee_screen, leftborder,rightborder,topborder,bottomborder]()
 		{
 			float borders[4] = {0.0,0.0,0.0,0.0};
 			borders[0] = leftborder->getValue();
@@ -987,7 +987,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 			SystemConf::getInstance()->set(ee_videomode+".ee_offsets", result);
 			runSystemCommand("ee_setborders "+result, "", nullptr);
-		});*/
+		});
 
 		mWindow->pushGui(bordersConfig);
 	});

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -144,30 +144,30 @@ static std::string toupper(std::string s)
 	return s;
 }
 
-static  int* getVideoModeDimensions(std::string ee_videomode, std::vector<std::string> reslist) 
+static  int* getVideoModeDimensions(std::string videomode, std::vector<std::string> reslist) 
 {
 	int screen[2] = {0, 0};
 	
-	if (ee_videomode == "480cvbs")
+	if (videomode == "480cvbs")
 	{
 		screen[0] = 720;
 		screen[1] = 480;
 		return screen;
   }
-	else if (ee_videomode == "576cvbs")
+	else if (videomode == "576cvbs")
 	{
 		screen[0] = 720;
 		screen[1] = 576;
 		return screen;
   }
 	
-	int pos = ee_videomode.find('x');
-	std::string tmp = ee_videomode;
+	int pos = videomode.find('x');
+	std::string tmp = videomode;
 
 	if (pos >= 0)
 	{
-		screen[0] = atoi(ee_videomode.substr(0, pos).c_str());
-		tmp = ee_videomode.substr(pos+1);
+		screen[0] = atoi(videomode.substr(0, pos).c_str());
+		tmp = videomode.substr(pos+1);
 	}
 		
 	pos = tmp.find('p');
@@ -186,9 +186,7 @@ static  int* getVideoModeDimensions(std::string ee_videomode, std::vector<std::s
 				break;
 			}
 		}
-	}	
-	//ee_dimensions[0] = screen[0];
-	//ee_dimensions[1] = screen[1];
+	}
 	return screen;
 }
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -146,17 +146,15 @@ static std::string toupper(std::string s)
 
 static int* getVideoModeDimensions(std::string ee_videomode, std::vector<std::string> reslist) 
 {
-	int screen[2] = {0, 0};
+	static int screen[2] = {0, 0};
 	int pos = ee_videomode.find('x');
-	std::string tmp;
+	std::string tmp = ee_videomode;
 
 	if (pos >= 0)
 	{
 		screen[0] = atoi(ee_videomode.substr(0, pos).c_str());
 		tmp = ee_videomode.substr(pos+1);
 	}
-	else
-		tmp = ee_videomode;
 		
 	pos = tmp.find('p');
 	if (pos < 0)

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -788,7 +788,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			if (emuelec_frame_buffer->changed()) {
 				std::string selectedFB = emuelec_frame_buffer->getSelected();
 				if (selectedFB == "auto")
-					return;
+					selectedFB = "";
 
 				SystemConf::getInstance()->set(ee_videomode+".ee_framebuffer", selectedFB);
 				mWindow->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -857,7 +857,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	auto ee_dimensions = std::make_shared<int*>(getVideoModeDimensions(ee_videomode, reslist));
 
 	char buffer[100];
-	sprintf(buffer, "dimensions: %.0f %.0f", ee_dimensions[0], ee_dimensions[1]);
+	sprintf(buffer, "dimensions: %.0f %.0f", *ee_dimensions[0], *ee_dimensions[1]);
 	mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
@@ -883,8 +883,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				return;
 			}
 			
-			int width = ee_dimensions[0];
-			int height = ee_dimensions[1];
+			int width = *ee_dimensions[0];
+			int height = *ee_dimensions[1];
 
 			std::string result = "0 0 "+
 				std::to_string(width-1)+" "+
@@ -897,7 +897,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	emuelec_frame_buffer->setSelectedChangedCallback([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, ee_dimensions](std::string name)
 	{
 		char buffer[100];
-		sprintf(buffer, "dim: %.0f %.0f", ee_dimensions[0], ee_dimensions[1]);
+		sprintf(buffer, "dim: %.0f %.0f", *ee_dimensions[0], *ee_dimensions[1]);
 		mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 				
 		fbSave(emuelec_frame_buffer->getSelected());
@@ -986,8 +986,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			//delete [] borders;
 		});
 
-		mWindow->pushGui(bordersConfig);*/
-	});
+		mWindow->pushGui(bordersConfig);
+	});*/
 
 #endif
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -879,7 +879,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions] {
 		std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
 		mWindow->displayNotificationMessage(_U("\uF011  ") + _(ee_borders.c_str()));
-		int borders[4] = {0, 0, 0, 0};
+		static int borders[4] = {0, 0, 0, 0};
 		if (!ee_borders.empty()) {
 			std::vector<int> savedBorders = int_explode(ee_borders, ' ');
 			if (savedBorders.size() == 4) {
@@ -892,12 +892,12 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		if (ee_framebuffer.empty())
 			return;
 
-		auto saveBorders = [mWindow, ee_videomode](int b[]) {
+		auto saveBorders = [mWindow, ee_videomode, borders]() {
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _("saveBorders"));
-			std::string result = std::to_string(b[0])+" "+
-				std::to_string(b[1])+" "+
-				std::to_string(b[2])+" "+
-				std::to_string(b[3]);
+			std::string result = std::to_string(borders[0])+" "+
+				std::to_string(borders[1])+" "+
+				std::to_string(borders[2])+" "+
+				std::to_string(borders[3]);
 			SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);
 		};
 			
@@ -931,15 +931,15 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		bordersConfig->addWithLabel(_("RIGHT BORDER"), rightborder);
 		bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
 
-		bordersConfig->addSaveFunc([mWindow, saveBorders, ee_videomode, dimensions, b = borders]()
+		bordersConfig->addSaveFunc([mWindow, saveBorders, ee_videomode, dimensions, borders]()
 		{
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _("bordersConfig->addSaveFunc"));
-			
-			saveBorders(b);
+
+			saveBorders();
 
 			bool hasBorder = false;
 			for(int i=0; i < 4; ++i) {
-				if (b[i] > 0) {
+				if (borders[i] > 0) {
 					hasBorder=true;
 					break;
 				}
@@ -947,10 +947,10 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			if (!hasBorder)
 				return;
 
-			std::string result = std::to_string(b[0])+" "+
-				std::to_string(b[1])+" "+
-				std::to_string(dimensions[0]-b[2]-1)+" "+
-				std::to_string(dimensions[1]-b[3]-1);
+			std::string result = std::to_string(borders[0])+" "+
+				std::to_string(borders[1])+" "+
+				std::to_string(dimensions[0]-borders[2]-1)+" "+
+				std::to_string(dimensions[1]-borders[3]-1);
 
 			SystemConf::getInstance()->set(ee_videomode+".ee_offsets", result);
 			runSystemCommand("ee_set_borders "+result, "", nullptr);			

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -897,21 +897,6 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		}
 	};
 
-	static sScreenBorders ee_borders;
-	//ee_borders.left = 0.0f;
-	//ee_borders.right = 0.0f;
-	//ee_borders.top = 0.0f;
-	//ee_borders.bottom = 0.0f;
-
-	if (!str_ee_offsets.empty()) {
-		std::vector<int> savedBorders = int_explode(str_ee_offsets, ' ');
-		if (savedBorders.size() == 4) {
-			ee_borders.left = (float) savedBorders[0];
-			ee_borders.top = (float) savedBorders[1];
-			ee_borders.right = (float) savedBorders[2];
-			ee_borders.bottom = (float) savedBorders[3];
-		}
-	}
 
 	emuelec_frame_buffer->setSelectedChangedCallback([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, ee_screen](std::string name)
 	{
@@ -922,8 +907,22 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		fbSave(emuelec_frame_buffer->getSelected());
 	});
 
-	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, ee_screen, ee_borders] {
+	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, ee_screen] {
+		static sScreenBorders ee_borders;
+		ee_borders.left = 0.0f;
+		ee_borders.right = 0.0f;
+		ee_borders.top = 0.0f;
+		ee_borders.bottom = 0.0f;
 
+		if (!str_ee_offsets.empty()) {
+			std::vector<int> savedBorders = int_explode(str_ee_offsets, ' ');
+			if (savedBorders.size() == 4) {
+				ee_borders.left = (float) savedBorders[0];
+				ee_borders.top = (float) savedBorders[1];
+				ee_borders.right = (float) savedBorders[2];
+				ee_borders.bottom = (float) savedBorders[3];
+			}
+		}
 		
 		char buffer[100];
 		sprintf(buffer, "border: %.0f %.0f %.0f %.0f", ee_borders.left, ee_borders.top, ee_borders.right, ee_borders.bottom);
@@ -936,8 +935,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		if (ee_framebuffer.empty())
 			return;
 
-		float width = float(ee_screen.width);
-		float height = float(ee_screen.height);
+		float width = (float)ee_screen.width;
+		float height = (float)ee_screen.height);
 
 		// borders
 		auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
@@ -951,12 +950,12 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			//ee_borders[1] = Math::round(newVal);
 		});
 		auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, width, 1.0f, "px");
-		rightborder->setValue(ee_borders.right-ee_screen.width+1);
+		rightborder->setValue((ee_borders.right > 0.0f) ? width-ee_borders.right+1 : 0.0f);
 		rightborder->setOnValueChanged([](const float &newVal) {
 			//ee_borders[2] = Math::round(newVal);
 		});
 		auto bottomborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
-		bottomborder->setValue(ee_borders.top-ee_screen.height+1);
+		bottomborder->setValue((ee_borders.top > 0.0f) ? height-ee_borders.top+1 : 0.0f);
 		bottomborder->setOnValueChanged([](const float &newVal) {
 			//ee_borders[3] = Math::round(newVal);
 		});
@@ -966,7 +965,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		bordersConfig->addWithLabel(_("TOP BORDER"), topborder);
 		bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
 
-		bordersConfig->addSaveFunc([mWindow, ee_videomode, ee_screen, leftborder,rightborder,topborder,bottomborder]()
+		/*bordersConfig->addSaveFunc([mWindow, ee_videomode, ee_screen, leftborder,rightborder,topborder,bottomborder]()
 		{
 			float borders[4] = {0.0,0.0,0.0,0.0};
 			borders[0] = leftborder->getValue();
@@ -988,8 +987,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 			SystemConf::getInstance()->set(ee_videomode+".ee_offsets", result);
 			runSystemCommand("ee_setborders "+result, "", nullptr);
-			//delete [] borders;
-		});
+		});*/
 
 		mWindow->pushGui(bordersConfig);
 	});

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -770,13 +770,13 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		framebuffer.push_back("640x480");
 		if (ee_framebuffer.empty())
 			ee_framebuffer = "auto";
-			
+
 		emuelec_frame_buffer->add("auto", "auto", ee_framebuffer == *it);
 		for (auto it = framebuffer.cbegin(); it != framebuffer.cend(); it++) {
 			emuelec_frame_buffer->add(*it, *it, ee_framebuffer == *it); 
 		}
 		dangerZone->addWithLabel(_("FRAME BUFFER"), emuelec_frame_buffer);
-	   	
+
 		dangerZone->addSaveFunc([mWindow, emuelec_frame_buffer, ee_videomode] {
 			if (emuelec_frame_buffer->changed()) {
 				std::string selectedFB = emuelec_frame_buffer->getSelected();
@@ -796,9 +796,10 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				return;
 
 
-			int[] borders = {0,0,0,0};
+			int borders[4] = {0,0,0,0};
 	    std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
-			if (!ee_borders.empty()) {
+			if (!ee_borders.empty()) 
+			{
 		    std::stringstream data(ee_borders);
 		    std::string line;
 				int i=0;
@@ -835,14 +836,14 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			bordersConfig->addWithLabel(_("RIGHT BORDER"), rightborder);
 			bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
 
-			bordersConfig->addSaveFunc([ee_videomode, borders]
+			bordersConfig->addSaveFunc([ee_videomode, borders, ScreenWidth, ScreenHeight]
 			{
 				std::string result = std::to_string(borders[0])+" "+
 					std::to_string(borders[1])+" "+
 					std::to_string(ScreenWidth-borders[2]-1)+" "+
 					std::to_string(ScreenHeight-borders[3]-1);
 				SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);
-				runSystemCommand("ee_set_borders "+result, "", nullptr);
+				//runSystemCommand("ee_set_borders "+result, "", nullptr);
 			});
 			mWindow->pushGui(bordersConfig);
 		});

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -149,7 +149,8 @@ static int* getVideoModeDimensions(std::string ee_videomode, std::vector<std::st
 	static int screen[2] = {0, 0};
 	int pos = 0;
 	std::string tmp;
-	if (pos = ee_videomode.find('x'))
+	pos = ee_videomode.find('x');
+	if (pos >= 0)
 	{
 		screen[0] = atoi(ee_videomode.substr(0, pos).c_str());
 		tmp = ee_videomode.substr(pos+1);
@@ -157,15 +158,14 @@ static int* getVideoModeDimensions(std::string ee_videomode, std::vector<std::st
 	else
 		tmp = ee_videomode;
 		
-	if (pos = tmp.find('p'))
+	pos = tmp.find('p');
+	if (pos < 0)
+		pos = tmp.find('i');
+	if (pos >= 0)
 	{
 		screen[1] = atoi(tmp.substr(0, pos).c_str());					
 	}
-	else if (pos = tmp.find('i'))
-	{
-		screen[1] = atoi(tmp.substr(0, pos).c_str());					
-	}
-	
+
 	if (screen[0] == 0) {
 		for (auto it = reslist.cbegin(); it != reslist.cend(); it++) {
 			int pos = (*it).find("x"+std::to_string(screen[0]));
@@ -834,7 +834,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	int screenWidth = 0;
 	int screenHeight = 0;
 
-	if (!ee_framebuffer.empty()) {
+	if (ee_framebuffer.empty()) {
 		int pos = ee_framebuffer.find('x');
 		screenWidth = atoi(ee_framebuffer.substr(0, pos).c_str());
 		screenHeight = atoi(ee_framebuffer.substr(pos+1).c_str());

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -931,15 +931,15 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		bordersConfig->addWithLabel(_("RIGHT BORDER"), rightborder);
 		bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
 
-		bordersConfig->addSaveFunc([mWindow, saveBorders, ee_videomode, dimensions, &borders]()
+		bordersConfig->addSaveFunc([mWindow, saveBorders, ee_videomode, dimensions, b = borders]()
 		{
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _("bordersConfig->addSaveFunc"));
 			
-			saveBorders(borders);
+			saveBorders(b);
 
 			bool hasBorder = false;
 			for(int i=0; i < 4; ++i) {
-				if (borders[i] > 0) {
+				if (b[i] > 0) {
 					hasBorder=true;
 					break;
 				}
@@ -947,10 +947,10 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			if (!hasBorder)
 				return;
 
-			std::string result = std::to_string(borders[0])+" "+
-				std::to_string(borders[1])+" "+
-				std::to_string(dimensions[0]-borders[2]-1)+" "+
-				std::to_string(dimensions[1]-borders[3]-1);
+			std::string result = std::to_string(b[0])+" "+
+				std::to_string(b[1])+" "+
+				std::to_string(dimensions[0]-b[2]-1)+" "+
+				std::to_string(dimensions[1]-b[3]-1);
 
 			SystemConf::getInstance()->set(ee_videomode+".ee_offsets", result);
 			runSystemCommand("ee_set_borders "+result, "", nullptr);			

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -144,9 +144,9 @@ static std::string toupper(std::string s)
 	return s;
 }
 
-int* getVideoModeDimensions(std::string videomode, std::vector<std::string> reslist) 
+static int* getVideoModeDimensions(std::string videomode, std::vector<std::string> reslist) 
 {
-	int screen[2] = {0, 0};
+	static int screen[2] = {0, 0};
 
 	if (videomode == "480cvbs")
 	{
@@ -856,9 +856,9 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 	int* ee_dimensions = getVideoModeDimensions(ee_videomode, reslist);
 
-	char buffer[100];
-	sprintf(buffer, "dimensions: %d %d", ee_dimensions[0], ee_dimensions[1]);
-	mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
+	//char buffer[100];
+	//sprintf(buffer, "dimensions: %d %d", ee_dimensions[0], ee_dimensions[1]);
+	//mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -825,8 +825,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	int borders[4] = {0, 0, 0, 0};
 	if (!ee_borders.empty()) {
 		std::vector<int> savedBorders = int_explode(ee_borders, ' ');
-		if (savedBorders && saveBorders.size() == 4) {
-			for(var i=0; i < 4; ++i)
+		if (savedBorders && savedBorders.size() == 4) {
+			for(int i=0; i < 4; ++i)
 				borders[i] = savedBorders[i];
 		}
 	}

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -749,19 +749,17 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	std::string ee_videomode = SystemConf::getInstance()->get("ee_videomode");
 	std::string ee_framebuffer = SystemConf::getInstance()->get(ee_videomode+".ee_framebuffer");
 
-	int pos;
-	int screenWidth;
-	int screenHeight;
+	int screenWidth = 0;
+	int screenHeight = 0;
 
 	if (!ee_framebuffer.empty()) {
-		pos = ee_framebuffer.find('x');
+		int pos = ee_framebuffer.find('x');
 		screenWidth = atoi(ee_framebuffer.substr(0, pos).c_str());
 		screenHeight = atoi(ee_framebuffer.substr(pos+1).c_str());
 	}
 
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
         std::vector<std::string> framebuffer;
-		framebuffer.push_back("auto");
 		framebuffer.push_back("3840x2160");
 		framebuffer.push_back("1920x1080");
 		framebuffer.push_back("1280x720");
@@ -772,7 +770,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		framebuffer.push_back("640x480");
 		if (ee_framebuffer.empty())
 			ee_framebuffer = "auto";
-						
+			
+		emuelec_frame_buffer->add("auto", "auto", ee_framebuffer == *it); }			
 		for (auto it = framebuffer.cbegin(); it != framebuffer.cend(); it++) {
 			emuelec_frame_buffer->add(*it, *it, ee_framebuffer == *it); }
 		dangerZone->addWithLabel(_("FRAME BUFFER"), emuelec_frame_buffer);
@@ -796,19 +795,15 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				return;
 
 
-			std::vector<int> borders;
+			int[] borders = {0,0,0,0};
 	    std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
-			if (ee_borders.empty())
-			{
-				for (int i=0; i < 4; ++i)
-					borders.push_back(0);
-			}
-			else {
+			if (!ee_borders.empty())
 		    std::stringstream data(ee_borders);
 		    std::string line;
+				int i=0;
 		    while(std::getline(data,line,' '))
 		    {
-		        borders.push_back(atoi(line.c_str()));
+		        borders[i++] = atoi(line.c_str());
 		    }
 			}
 
@@ -825,13 +820,13 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			});
 			auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenWidth)/2.0f, 1.0f, "px");
 			rightborder->setValue((float)borders[2]);
-			rightborder->setOnValueChanged([&borders,screenWidth](const float &newVal) {
-				borders[2] = screenWidth-1-(int)Math::round(newVal);
+			rightborder->setOnValueChanged([&borders](const float &newVal) {
+				borders[2] = (int)Math::round(newVal);
 			});
 			auto bottomborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenHeight)/2.0f, 1.0f, "px");
 			bottomborder->setValue((float)borders[3]);
-			bottomborder->setOnValueChanged([&borders,screenHeight](const float &newVal) {
-				borders[3] = screenHeight-1-(int)Math::round(newVal);
+			bottomborder->setOnValueChanged([&borders](const float &newVal) {
+				borders[3] = (int)Math::round(newVal);
 			});
 
 			bordersConfig->addWithLabel(_("LEFT BORDER"), leftborder);
@@ -843,8 +838,8 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			{
 				std::string result = std::to_string(borders[0])+" "+
 					std::to_string(borders[1])+" "+
-					std::to_string(borders[2])+" "+
-					std::to_string(borders[3]);
+					std::to_string(ScreenWidth-borders[2]-1)+" "+
+					std::to_string(ScreenHeight-borders[3]-1);
 				SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);
 				runSystemCommand("ee_set_borders "+result, "", nullptr);
 			});

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -813,11 +813,13 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			leftborder->setValue((float)borders[0]);
 			leftborder->setOnValueChanged([&borders](const float &newVal) {
 				borders[0] = (int)Math::round(newVal);
+				rightborder->setValue((float)borders[0]);
 			});
 			auto topborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenHeight)/2.0f, 1.0f, "px");
 			topborder->setValue((float)borders[1]);
 			topborder->setOnValueChanged([&borders](const float &newVal) {
 				borders[1] = (int)Math::round(newVal);
+				bottomborder->setValue((float)borders[1]);
 			});
 			auto rightborder = std::make_shared<SliderComponent>(mWindow, 0.0f, float(screenWidth)/2.0f, 1.0f, "px");
 			rightborder->setValue((float)borders[2]);
@@ -842,7 +844,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 					std::to_string(screenWidth-borders[2]-1)+" "+
 					std::to_string(screenHeight-borders[3]-1);
 				SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);
-				//runSystemCommand("ee_set_borders "+result, "", nullptr);
+				runSystemCommand("ee_set_borders "+result, "", nullptr);
 			});
 			mWindow->pushGui(bordersConfig);
 		});

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -931,7 +931,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		bordersConfig->addWithLabel(_("RIGHT BORDER"), rightborder);
 		bordersConfig->addWithLabel(_("BOTTOM BORDER"), bottomborder);
 
-		bordersConfig->addSaveFunc([mWindow, ee_videomode, dimensions, &borders]()
+		bordersConfig->addSaveFunc([mWindow, saveBorders, ee_videomode, dimensions, &borders]()
 		{
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _("bordersConfig->addSaveFunc"));
 			

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -830,7 +830,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 #ifdef _ENABLEEMUELEC
 	std::string ee_videomode = SystemConf::getInstance()->get("ee_videomode");
-	if (Utils::FileSystem::exists("/storage/.config/EE_VIDEO_MODE")
+	if (Utils::FileSystem::exists("/storage/.config/EE_VIDEO_MODE"))
 		ee_videomode = getShOutput(R"(cat /storage/.config/EE_VIDEO_MODE)");
 
 	std::string ee_framebuffer = SystemConf::getInstance()->get(ee_videomode+".ee_framebuffer");

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -767,12 +767,12 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			emuelec_frame_buffer->add(*it, *it, ee_framebuffer == *it); }
 		dangerZone->addWithLabel(_("FRAME BUFFER"), emuelec_frame_buffer);
 	   	
-		dangerZone->addSaveFunc([mWindow, emuelec_video_mode, emuelec_frame_buffer, ee_videomode] {
-			if (emuelec_video_mode->changed()) {
+		dangerZone->addSaveFunc([mWindow, emuelec_frame_buffer, ee_videomode] {
+			if (emuelec_frame_buffer->changed()) {
 				std::string selectedFB = emuelec_frame_buffer->getSelected();
 				int pos = selectedFB.find('x');
-				std::string screenWidth = selectedFB.substr(0, pos);
-				std::string screenHeight = selectedFB.substr(pos+1);
+				int screenWidth = atoi(selectedFB.substr(0, pos));
+				int screenHeight = atoi(selectedFB.substr(pos+1));
 
 				std::string ee_videomode = SystemConf::getInstance()->get("ee_videomode");
 				SystemConf::getInstance()->set(ee_videomode+".ee_framebuffer", screenWidth+" "+screenHeight);
@@ -782,13 +782,13 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 		if (!ee_framebuffer.empty() && ee_framebuffer != "auto") {
 			dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer] { 
-				GuiSettings* bordersConfig = new GuiSettings(window, _("FRAME BORDERS"));
+				GuiSettings* bordersConfig = new GuiSettings(mWindow, _("FRAME BORDERS"));
 				if (ee_framebuffer.empty())
 					return;
 
 				int pos = ee_framebuffer.find('x');
-				std::string screenWidth = ee_framebuffer.substr(0, pos);
-				std::string screenHeight = ee_framebuffer.substr(pos+1);
+				int screenWidth = atoi(ee_framebuffer.substr(0, pos));
+				int screenHeight = atoi(ee_framebuffer.substr(pos+1));
 
 				std::vector<std::string> borders;
 		    std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
@@ -800,24 +800,24 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		    }
 
 				// borders
-				auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.f, atof(screenWidth)/2, 1.f, "px");
+				auto leftborder = std::make_shared<SliderComponent>(mWindow, 0.f, float(screenWidth)/2, 1.f, "px");
 				leftborder->setValue((float)borders[0]);
-				leftborder->setOnValueChanged([](const float &newVal) {
+				leftborder->setOnValueChanged([borders](const float &newVal) {
 					borders[0] = (int)Math::round(newVal);
 				});
-				auto topborder = std::make_shared<SliderComponent>(mWindow, 0.f, atof(screenHeight)/2, 1.f, "px");
+				auto topborder = std::make_shared<SliderComponent>(mWindow, 0.f, float(screenHeight)/2, 1.f, "px");
 				topborder->setValue((float)borders[1]);
-				topborder->setOnValueChanged([](const float &newVal) {
+				topborder->setOnValueChanged([borders](const float &newVal) {
 					borders[1] = (int)Math::round(newVal);
 				});
-				auto rightborder = std::make_shared<SliderComponent>(mWindow, atof(screenWidth)-1, atof(screenWidth)/2, -1.f, "px");
+				auto rightborder = std::make_shared<SliderComponent>(mWindow, float(screenWidth)-1, float(screenWidth)/2, -1.f, "px");
 				rightborder->setValue((float)borders[2]);
-				rightborder->setOnValueChanged([](const float &newVal) {
+				rightborder->setOnValueChanged([borders](const float &newVal) {
 					borders[2] = (int)Math::round(newVal);
 				});
-				auto bottomborder = std::make_shared<SliderComponent>(mWindow, atof(screenHeight)-1, atof(screenHeight)/2, -1.f, "px");
+				auto bottomborder = std::make_shared<SliderComponent>(mWindow, float(screenHeight)-1, float(screenHeight)/2, -1.f, "px");
 				bottomborder->setValue((float)borders[3]);
-				bottomborder->setOnValueChanged([](const float &newVal) {
+				bottomborder->setOnValueChanged([borders](const float &newVal) {
 					borders[3] = (int)Math::round(newVal);
 				});
 
@@ -826,7 +826,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				bordersConfig->addWithLabel(_("RIGHT BORDER"), rightborder);
 				bordersConfig->addWithLabel(_("BOTTOM BORDER"), botttomborder);
 
-				bordersConfig->addSaveFunc([this, ee_videomode, borders]
+				bordersConfig->addSaveFunc([ee_videomode, borders]
 				{
 					std::string result = borders[0]+" "+borders[1]+" "+borders[2]+" "+borders[3];
 					SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -906,12 +906,12 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		runSystemCommand("ee_set_borders "+result, "", nullptr);			
 	});
 
-	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions, borders] { 
+	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions, &borders] { 
 		GuiSettings* bordersConfig = new GuiSettings(mWindow, _("FRAME BORDERS"));
 		if (ee_framebuffer.empty())
 			return;
 
-		auto saveBorders = [ee_videomode, dimensions, borders]() {
+		auto saveBorders = [ee_videomode, dimensions, &borders]() {
 			std::string result = std::to_string(borders[0])+" "+
 				std::to_string(borders[1])+" "+
 				std::to_string(borders[2])+" "+

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -854,10 +854,10 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		reslist.push_back("800 600");
 		reslist.push_back("640 480");
 
-	auto ee_dimensions = std::make_shared<int>(getVideoModeDimensions(ee_videomode, reslist));
+	auto ee_dimensions = std::make_shared<int*>(getVideoModeDimensions(ee_videomode, reslist));
 
 	char buffer[100];
-	sprintf(buffer, "dimensions: %.0f %.0f", ee_dimensions[0], ee_dimensions[1]);
+	sprintf(buffer, "dimensions: %.0f %.0f", ee_dimensions.get()[0], ee_dimensions.get()[1]);
 	mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -837,25 +837,22 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	if (ee_framebuffer.empty()) {
 		ee_framebuffer = "auto";
 	}
-	else {
-		ee_framebuffer.replace(ee_framebuffer.find(" "),1,"x");
-	}
 
 	std::vector<std::string> reslist;
-		reslist.push_back("3840x2160");
-		reslist.push_back("2560x1440");
-		reslist.push_back("1920x1080");
-		reslist.push_back("1280x720");
-		reslist.push_back("720x480");
-		reslist.push_back("768x576");
-		reslist.push_back("1680x1050");
-		reslist.push_back("1440x900");
-		reslist.push_back("1280x1024");
-		reslist.push_back("1280x960");
-		reslist.push_back("1280x800");
-		reslist.push_back("1024x768");
-		reslist.push_back("800x600");
-		reslist.push_back("640x480");
+		reslist.push_back("3840 2160");
+		reslist.push_back("2560 1440");
+		reslist.push_back("1920 1080");
+		reslist.push_back("1280 720");
+		reslist.push_back("720 480");
+		reslist.push_back("768 576");
+		reslist.push_back("1680 1050");
+		reslist.push_back("1440 900");
+		reslist.push_back("1280 1024");
+		reslist.push_back("1280 960");
+		reslist.push_back("1280 800");
+		reslist.push_back("1024 768");
+		reslist.push_back("800 600");
+		reslist.push_back("640 480");
 
 	int* dimensions = getVideoModeDimensions(ee_videomode, reslist);
 
@@ -863,16 +860,16 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 	emuelec_frame_buffer->add("auto", "auto", ee_framebuffer == "auto");
 	for (auto it = reslist.cbegin(); it != reslist.cend(); it++) {
-		emuelec_frame_buffer->add(*it, *it, ee_framebuffer == *it); 
+		std::string lbl = *it;
+		lbl = lbl.replace(lbl.find(" "),1,"x");
+		emuelec_frame_buffer->add(lbl, *it, ee_framebuffer == *it); 
 	}
 	dangerZone->addWithLabel(_("FRAME BUFFER"), emuelec_frame_buffer);
 
 	auto fbSave = [mWindow, emuelec_frame_buffer, ee_videomode, dimensions] (std::string selectedFB) {
-		if (emuelec_frame_buffer->changed()) {
+		if (emuelec_frame_buffer.changed()) {
 			if (selectedFB == "auto")
 				selectedFB = "";
-			else
-				selectedFB.replace(selectedFB.find("x"),1," ");
 
 			SystemConf::getInstance()->set(ee_videomode+".ee_framebuffer", selectedFB);
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
@@ -895,12 +892,12 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 	emuelec_frame_buffer->setSelectedChangedCallback([mWindow, emuelec_frame_buffer, fbSave, ee_videomode, dimensions](std::string name)
 	{
-		fbSave(name);
+		fbSave(emuelec_frame_buffer->getSelected());
 	});
 
 	dangerZone->addEntry(_("ADJUST FRAME BORDERS"), true, [mWindow, ee_videomode, ee_framebuffer, dimensions] {
-		std::string ee_borders = SystemConf::getInstance()->get(ee_videomode+".ee_borders");
-		static int borders[4] = {0, 0, 0, 0};
+		std::string ee_borders = SystemConf::getInstance()->get(*ee_videomode+".ee_borders");
+		int borders[4] = {0,0,0,0};
 		if (!ee_borders.empty()) {
 			std::vector<int> savedBorders = int_explode(ee_borders, ' ');
 			if (savedBorders.size() == 4) {
@@ -910,7 +907,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		}
 
 		GuiSettings* bordersConfig = new GuiSettings(mWindow, _("FRAME BORDERS"));
-		if (ee_framebuffer.empty())
+		if (ee_framebuffer->empty())
 			return;
 
 		auto saveBorders = [mWindow, ee_videomode, borders]() {
@@ -918,7 +915,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				std::to_string(borders[1])+" "+
 				std::to_string(borders[2])+" "+
 				std::to_string(borders[3]);
-			SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);
+			SystemConf::getInstance()->set(*ee_videomode+".ee_borders", result);
 		};
 			
 		float width = float(dimensions[0])/2.0f;
@@ -961,7 +958,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				std::to_string(dimensions[1]-borders[3]-1);
 			
 			SystemConf::getInstance()->set(ee_videomode+".ee_offsets", result);
-			runSystemCommand("ee_set_borders "+result, "", nullptr);			
+			//runSystemCommand("ee_set_borders "+result, "", nullptr);			
 		});
 
 		mWindow->pushGui(bordersConfig);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -168,7 +168,7 @@ static int* getVideoModeDimensions(std::string ee_videomode, std::vector<std::st
 		for (auto it = reslist.cbegin(); it != reslist.cend(); it++) {
 			int pos = (*it).find("x"+std::to_string(screen[1]));
 			if (pos >= 0) {
-				screen[0] = atoi(ee_videomode.substr(0,pos).c_str());
+				screen[0] = atoi((*it).substr(0,pos).c_str());
 				break;
 			}
 		}

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -168,7 +168,7 @@ static int* getVideoModeDimensions(std::string ee_videomode, std::vector<std::st
 
 	if (screen[0] == 0) {
 		for (auto it = reslist.cbegin(); it != reslist.cend(); it++) {
-			int pos = (*it).find("x"+std::to_string(screen[0]));
+			int pos = (*it).find("x"+std::to_string(screen[1]));
 			if (pos >= 0) {
 				screen[0] = atoi(ee_videomode.substr(0,pos).c_str());
 				break;
@@ -834,7 +834,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 	int screenWidth = 0;
 	int screenHeight = 0;
 
-	if (ee_framebuffer.empty()) {
+	if (!ee_framebuffer.empty()) {
 		int pos = ee_framebuffer.find('x');
 		screenWidth = atoi(ee_framebuffer.substr(0, pos).c_str());
 		screenHeight = atoi(ee_framebuffer.substr(pos+1).c_str());
@@ -859,11 +859,13 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			SystemConf::getInstance()->set(ee_videomode+".ee_framebuffer", selectedFB);
 			mWindow->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
 			
-			if (selectedFB == "")
+			if (selectedFB == "") {
+				SystemConf::getInstance()->set(ee_videomode+".ee_offsets", "");
 				return;
+			}
 			
 			std::string ee_offsets = SystemConf::getInstance()->get(ee_videomode+".ee_offsets");
-			if (ee_offsets.empty())
+			if (!ee_offsets.empty())
 				return;
 
 			std::string result = "0 0 "+

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -957,7 +957,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			//ee_borders[2] = Math::round(newVal);
 		});
 		auto bottomborder = std::make_shared<SliderComponent>(mWindow, 0.0f, height, 1.0f, "px");
-		bottomborder->setValue((ee_borders.top > 0.0f) ? height-ee_borders.top-1 : 0.0f);
+		bottomborder->setValue((ee_borders.bottom > 0.0f) ? height-ee_borders.bottom-1 : 0.0f);
 		bottomborder->setOnValueChanged([](const float &newVal) {
 			//ee_borders[3] = Math::round(newVal);
 		});
@@ -988,7 +988,7 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				std::to_string(ee_screen.height-(borders[3])-1);
 
 			SystemConf::getInstance()->set(ee_videomode+".ee_offsets", result);
-			//runSystemCommand("ee_setborders "+result, "", nullptr);
+			runSystemCommand("ee_setborders "+result, "", nullptr);
 		});
 
 		mWindow->pushGui(bordersConfig);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -792,6 +792,20 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 
 				SystemConf::getInstance()->set(ee_videomode+".ee_framebuffer", selectedFB);
 				mWindow->displayNotificationMessage(_U("\uF011  ") + _("A REBOOT OF THE SYSTEM IS REQUIRED TO APPLY THE NEW CONFIGURATION"));
+				
+				if (selectedFB == "")
+					return;
+					
+				int pos = selectedFB.find('x');
+				screenWidth = atoi(selectedFB.substr(0, pos).c_str());
+				screenHeight = atoi(selectedFB.substr(pos+1).c_str());
+
+				result = "0 0 "+
+					std::to_string(screenWidth-1)+" "+
+					std::to_string(screenHeight-1);
+
+				SystemConf::getInstance()->set(ee_videomode+".ee_offsets", result);
+				runSystemCommand("ee_set_borders "+result, "", nullptr);
 			}
 		});
 
@@ -849,13 +863,13 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 					std::to_string(borders[3]);
 				SystemConf::getInstance()->set(ee_videomode+".ee_borders", result);
 
-				result = std::to_string(borders[0])+" "+
+				std::string result2 = std::to_string(borders[0])+" "+
 					std::to_string(borders[1])+" "+
 					std::to_string(screenWidth-borders[2]-1)+" "+
 					std::to_string(screenHeight-borders[3]-1);
 
-				SystemConf::getInstance()->set(ee_videomode+".ee_offsets", result);
-				runSystemCommand("ee_set_borders "+result, "", nullptr);
+				SystemConf::getInstance()->set(ee_videomode+".ee_offsets", result2);
+				runSystemCommand("ee_set_borders "+result2, "", nullptr);
 			});
 			mWindow->pushGui(bordersConfig);
 		});

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -144,10 +144,10 @@ static std::string toupper(std::string s)
 	return s;
 }
 
-static int* getVideoModeDimensions(std::string videomode, std::vector<std::string> reslist) 
+int* getVideoModeDimensions(std::string videomode, std::vector<std::string> reslist) 
 {
-	static int screen[2] = {0, 0};
-	
+	int screen[2] = {0, 0};
+
 	if (videomode == "480cvbs")
 	{
 		screen[0] = 720;
@@ -855,6 +855,10 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		reslist.push_back("640 480");
 
 	int* ee_dimensions = getVideoModeDimensions(ee_videomode, reslist);
+
+	char buffer[100];
+	sprintf(buffer, "dimensions: %.0f %.0f", ee_dimensions[0], ee_dimensions[1]);
+	mWindow->displayNotificationMessage(_U("\uF011  ") + _(buffer));
 
 	auto emuelec_frame_buffer = std::make_shared< OptionListComponent<std::string> >(mWindow, "VIDEO MODE", false);
 

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -140,9 +140,6 @@ public:
   static std::shared_ptr<OptionListComponent<std::string>> btn_choice;
   static std::shared_ptr<OptionListComponent<std::string>> del_choice;
   static std::shared_ptr<OptionListComponent<std::string>> edit_choice;
-
-	static int* ee_dimensions;
-	static float ee_borders[4];	
 #endif
 };
 

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -38,6 +38,23 @@ struct DecorationSetInfo
 	std::string imageUrl;
 };
 
+#ifdef _ENABLEEMUELEC
+struct sScreenDimensions
+{
+	int width;
+	int height;
+};
+
+struct sScreenBorders
+{
+	float left;
+	float right;
+	float top;
+	float bottom;
+};
+
+#endif
+
 class GuiMenu : public GuiComponent
 {
 public:

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -72,10 +72,6 @@ private:
     static void openDangerZone(Window* mWindow, std::string configName);
     static void createGamepadConfig(Window* window, GuiSettings* systemConfiguration);
     static void openExternalMounts(Window* mWindow, std::string configName);
-	
-	static int* ee_dimensions;
-	static float ee_borders[4];
-
 #endif
 
 	void openSystemSettings();
@@ -144,6 +140,9 @@ public:
   static std::shared_ptr<OptionListComponent<std::string>> btn_choice;
   static std::shared_ptr<OptionListComponent<std::string>> del_choice;
   static std::shared_ptr<OptionListComponent<std::string>> edit_choice;
+
+	static int* ee_dimensions;
+	static float ee_borders[4];	
 #endif
 };
 

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -89,6 +89,7 @@ private:
     static void openDangerZone(Window* mWindow, std::string configName);
     static void createGamepadConfig(Window* window, GuiSettings* systemConfiguration);
     static void openExternalMounts(Window* mWindow, std::string configName);
+		static void addFrameBufferOptions(Window* mWindow, GuiSettings* guiSettings, std::string configName, std::string header);
 #endif
 
 	void openSystemSettings();

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -73,7 +73,7 @@ private:
     static void createGamepadConfig(Window* window, GuiSettings* systemConfiguration);
     static void openExternalMounts(Window* mWindow, std::string configName);
 	
-	static int ee_dimensions[2];
+	static int* ee_dimensions;
 	static float ee_borders[4];
 #endif
 

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -38,6 +38,23 @@ struct DecorationSetInfo
 	std::string imageUrl;
 };
 
+#ifdef _ENABLEEMUELEC
+struct sScreenDimensions
+{
+	int width;
+	int height;
+};
+
+struct sScreenBorders
+{
+	float left;
+	float right;
+	float top;
+	float bottom;
+};
+
+#endif
+
 class GuiMenu : public GuiComponent
 {
 public:
@@ -73,7 +90,7 @@ private:
     static void createGamepadConfig(Window* window, GuiSettings* systemConfiguration);
     static void openExternalMounts(Window* mWindow, std::string configName);
 #endif
-	
+
 	void openSystemSettings();
 	void openGamesSettings();
 	void openControllersSettings(int autoSel = 0);

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -75,6 +75,7 @@ private:
 	
 	static int* ee_dimensions;
 	static float ee_borders[4];
+
 #endif
 
 	void openSystemSettings();

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -73,8 +73,8 @@ private:
     static void createGamepadConfig(Window* window, GuiSettings* systemConfiguration);
     static void openExternalMounts(Window* mWindow, std::string configName);
 	
-	int ee_dimensions[2];
-	float ee_borders[4];
+	static int ee_dimensions[2];
+	static float ee_borders[4];
 #endif
 
 	void openSystemSettings();

--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -72,8 +72,11 @@ private:
     static void openDangerZone(Window* mWindow, std::string configName);
     static void createGamepadConfig(Window* window, GuiSettings* systemConfiguration);
     static void openExternalMounts(Window* mWindow, std::string configName);
-#endif
 	
+	int ee_dimensions[2];
+	float ee_borders[4];
+#endif
+
 	void openSystemSettings();
 	void openGamesSettings();
 	void openControllersSettings(int autoSel = 0);


### PR DESCRIPTION
Allows the user in Emuelec Settings >> Danger Mode, To set the framebuffer different from display resolution. This is useful in cvbs mode or to display a certain resolution compatible with your display, and have a different framebuffer resolution in ES or in Emulator mode. 
Also supports adding black borders to the framebuffer for fine tuning a display output.

edit:
apologies on the amount of commits I cannot squash them because I merged.

designed to work with EE PR:
https://github.com/EmuELEC/EmuELEC/pull/1208
