### PR TITLE
EE - Add test function to emuelec-utils. Fix to ES PR #69

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1544,6 +1544,7 @@ void GuiMenu::openSystemSettings()
 #ifdef _ENABLEEMUELEC
 	auto emuelec_timezones = std::make_shared<OptionListComponent<std::string> >(mWindow, _("TIMEZONE"), false);
 	std::string currentTimezone = SystemConf::getInstance()->get("system.timezone");
+	std::string test_shell = getShOutput(R"(/usr/bin/emuelec-utils test)");
 	if (!test_shell.compare("success")) {
 		if (currentTimezone.empty())
 			currentTimezone = std::string(getShOutput(R"(/usr/bin/emuelec-utils current_timezone)"));


### PR DESCRIPTION
PR #69 has some missing code for the variable test_shell which is causing a compilation error. This PR's objective is to fix the error so it compiles and works fine again.

It is dependent on and this also needs to be pushed:
https://github.com/EmuELEC/EmuELEC/pull/1234
