### PR TITLE
[Feature] Being able to hide the sortname from the gamelist display.

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -3956,6 +3956,22 @@ void GuiMenu::openThemeConfiguration(Window* mWindow, GuiComponent* s, std::shar
 				themeconfig->setVariable("reloadAll", true);
 		});
 
+#ifdef _ENABLEEMUELEC
+	auto enable_hideSortName = std::make_shared<SwitchComponent>(window);
+	bool hideSortNameEnabled = SystemConf::getInstance()->get(system->getName() + ".hideSortNames") == "1";
+	enable_hideSortName->setState(hideSortNameEnabled);
+	themeconfig->addWithLabel(_("HIDE SORTNAMES IN GAMELIST"), enable_hideSortName);
+
+	themeconfig->addSaveFunc([enable_hideSortName, mWindow, system, themeconfig] {
+		bool hideSortNameEnabled = enable_hideSortName->getState();
+		bool hideSortNameEnabled2 = SystemConf::getInstance()->get(system->getName() + ".hideSortNames") == "1";
+		if (hideSortNameEnabled != hideSortNameEnabled2)
+			themeconfig->setVariable("reloadAll", true);
+
+		SystemConf::getInstance()->set(system->getName() + ".hideSortNames", hideSortNameEnabled ? "1" : "");
+	});
+#endif
+
 		// Show filenames
 		auto defFn = Settings::getInstance()->getBool("ShowFilenames") ? _("YES") : _("NO");
 		auto curFn = Settings::getInstance()->getString(system->getName() + ".ShowFilenames");

--- a/es-app/src/views/gamelist/GameNameFormatter.cpp
+++ b/es-app/src/views/gamelist/GameNameFormatter.cpp
@@ -10,6 +10,10 @@
 #include "SaveStateRepository.h"
 #include "CollectionSystemManager.h"
 
+#ifdef _ENABLEEMUELEC
+	#include "SystemConf.h"
+#endif
+
 #define FOLDERICON	 _U("\uF07C ")
 #define FAVORITEICON _U("\uF006 ")
 
@@ -118,8 +122,11 @@ std::string GameNameFormatter::getDisplayName(FileData* fd, bool showFolderIcon)
 {
 	std::string name = fd->getName();
 #ifdef _ENABLEEMUELEC
-	if ((mSortId == FileSorts::SORTNAME_ASCENDING || mSortId == FileSorts::SORTNAME_DESCENDING) && !fd->getSortName().empty())
-		name = fd->getSortName();
+	std::string hideSortNames = SystemConf::getInstance()->get(fd->getSystem()->getName() + ".hideSortNames");
+	if (hideSortNames.empty()) {
+		if ((mSortId == FileSorts::SORTNAME_ASCENDING || mSortId == FileSorts::SORTNAME_DESCENDING) && !fd->getSortName().empty())
+			name = fd->getSortName();
+	}
 #endif
 
 	bool showSystemNameByFile = (fd->getType() == GAME || fd->getParent() == nullptr || fd->getParent()->getName() != "collections");


### PR DESCRIPTION
[Feature] Being able to hide the sortname from the gamelist display.

needs testing.

To test enable hide sort names by in gamelist:
[select] >> View options >> View Customization >> Hide Sortnames in Gamelist.

ref:
https://github.com/EmuELEC/EmuELEC/issues/1264