### PR TITLE
ES - added feature to select configurable virtual keyboards.

### DIFF
--- a/es-app/src/CustomFeatures.cpp
+++ b/es-app/src/CustomFeatures.cpp
@@ -59,6 +59,7 @@ EmulatorFeatures::Features EmulatorFeatures::parseFeatures(const std::string fea
 		if (trim == "joybtnremap") ret = ret | EmulatorFeatures::Features::joybtnremap;
 		if (trim == "hlebios") ret = ret | EmulatorFeatures::Features::hlebios;
 		if (trim == "cloudsave") ret = ret | EmulatorFeatures::Features::cloudsave;
+		if (trim == "gptokeyb") ret = ret | EmulatorFeatures::Features::gptokeyb;
 #endif
 	}
 

--- a/es-app/src/CustomFeatures.h
+++ b/es-app/src/CustomFeatures.h
@@ -97,6 +97,7 @@ public:
 		hlebios = 4194304,
     joybtnremap = 8388608,
 		cloudsave = 16777216,
+		gptokeyb = 33554432,
 #endif
 		all = 0x0FFFFFFF
 	};

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -5158,6 +5158,42 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	auto customFeatures = systemData->getCustomFeatures(currentEmulator, currentCore);
 
 #ifdef _ENABLEEMUELEC
+		// DOSBOX - conf gptokeyb.
+		if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::gptokeyb) || currentEmulator == "ports")
+		{
+				auto emuelec_virtual_kb = std::make_shared< OptionListComponent<std::string> >(mWindow, "Virtual Keyboard", false);
+				std::vector<std::string> virtual_kb;
+
+				std::string def_vkb;
+				for(std::stringstream ss(Utils::Platform::getShOutput(R"(/usr/bin/emuelec-utils get_filenames_no_ext /emuelec/configs/gptokeyb)")); getline(ss, def_vkb, ','); ) {
+					if (!std::count(virtual_kb.begin(), virtual_kb.end(), def_vkb)) {
+						 virtual_kb.push_back(def_vkb);
+					}
+				}
+
+				std::string index = SystemConf::getInstance()->get(configName + ".gptokeyb");
+				if (index.empty())
+					index = "auto";
+
+				emuelec_virtual_kb->add(_("AUTO"), "auto", index == "auto");
+				for (auto it = virtual_kb.cbegin(); it != virtual_kb.cend(); it++) {
+					emuelec_virtual_kb->add(*it, *it, index == *it);
+				}
+			
+			systemConfiguration->addWithLabel(_("VIRTUAL KEYBOARD"), emuelec_virtual_kb);
+
+			systemConfiguration->addSaveFunc([mWindow, configName, emuelec_virtual_kb] {
+				std::string vkb_choice = emuelec_virtual_kb->getSelected();
+
+				if (vkb_choice == "auto")
+					vkb_choice = "";
+
+				SystemConf::getInstance()->set(configName + ".gptokeyb", vkb_choice);
+			});
+		}
+#endif
+
+#ifdef _ENABLEEMUELEC
 	// NATIVE VIDEO.
 
 	if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::nativevideo))

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -5161,35 +5161,35 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 		// Conf gptokeyb.
 		if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::gptokeyb) || currentEmulator == "ports")
 		{
-				auto emuelec_virtual_kb = std::make_shared< OptionListComponent<std::string> >(mWindow, "Virtual Keyboard", false);
-				std::vector<std::string> virtual_kb;
+			auto emuelec_virtual_kb = std::make_shared< OptionListComponent<std::string> >(mWindow, "Virtual Keyboard", false);
+			std::vector<std::string> virtual_kb;
 
-				std::string def_vkb;
-				for(std::stringstream ss(Utils::Platform::getShOutput(R"(/usr/bin/emuelec-utils get_filenames_no_ext /emuelec/configs/gptokeyb)")); getline(ss, def_vkb, ','); ) {
-					if (!std::count(virtual_kb.begin(), virtual_kb.end(), def_vkb)) {
-						 virtual_kb.push_back(def_vkb);
-					}
+			std::string def_vkb;
+			for(std::stringstream ss(Utils::Platform::getShOutput(R"(/usr/bin/emuelec-utils get_filenames_no_ext /emuelec/configs/gptokeyb)")); getline(ss, def_vkb, ','); ) {
+				if (!std::count(virtual_kb.begin(), virtual_kb.end(), def_vkb)) {
+					 virtual_kb.push_back(def_vkb);
 				}
+			}
 
-				std::string index = SystemConf::getInstance()->get(configName + ".gptokeyb");
-				if (index.empty())
-					index = "auto";
+			std::string index = SystemConf::getInstance()->get(configName + ".gptokeyb");
+			if (index.empty())
+				index = "auto";
 
-				emuelec_virtual_kb->add(_("AUTO"), "auto", index == "auto");
-				for (auto it = virtual_kb.cbegin(); it != virtual_kb.cend(); it++) {
-					emuelec_virtual_kb->add(*it, *it, index == *it);
-				}
-			
-				systemConfiguration->addWithLabel(_("VIRTUAL KEYBOARD"), emuelec_virtual_kb);
+			emuelec_virtual_kb->add(_("AUTO"), "auto", index == "auto");
+			for (auto it = virtual_kb.cbegin(); it != virtual_kb.cend(); it++) {
+				emuelec_virtual_kb->add(*it, *it, index == *it);
+			}
+		
+			systemConfiguration->addWithLabel(_("VIRTUAL KEYBOARD"), emuelec_virtual_kb);
 
-				systemConfiguration->addSaveFunc([mWindow, configName, emuelec_virtual_kb] {
-					std::string vkb_choice = emuelec_virtual_kb->getSelected();
+			systemConfiguration->addSaveFunc([mWindow, configName, emuelec_virtual_kb] {
+				std::string vkb_choice = emuelec_virtual_kb->getSelected();
 
-					if (vkb_choice == "auto")
-						vkb_choice = "";
+				if (vkb_choice == "auto")
+					vkb_choice = "";
 
-					SystemConf::getInstance()->set(configName + ".gptokeyb", vkb_choice);
-				});
+				SystemConf::getInstance()->set(configName + ".gptokeyb", vkb_choice);
+			});
 		}
 #endif
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -5158,7 +5158,7 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 	auto customFeatures = systemData->getCustomFeatures(currentEmulator, currentCore);
 
 #ifdef _ENABLEEMUELEC
-		// DOSBOX - conf gptokeyb.
+		// Conf gptokeyb.
 		if (systemData->isFeatureSupported(currentEmulator, currentCore, EmulatorFeatures::gptokeyb) || currentEmulator == "ports")
 		{
 				auto emuelec_virtual_kb = std::make_shared< OptionListComponent<std::string> >(mWindow, "Virtual Keyboard", false);
@@ -5180,16 +5180,16 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 					emuelec_virtual_kb->add(*it, *it, index == *it);
 				}
 			
-			systemConfiguration->addWithLabel(_("VIRTUAL KEYBOARD"), emuelec_virtual_kb);
+				systemConfiguration->addWithLabel(_("VIRTUAL KEYBOARD"), emuelec_virtual_kb);
 
-			systemConfiguration->addSaveFunc([mWindow, configName, emuelec_virtual_kb] {
-				std::string vkb_choice = emuelec_virtual_kb->getSelected();
+				systemConfiguration->addSaveFunc([mWindow, configName, emuelec_virtual_kb] {
+					std::string vkb_choice = emuelec_virtual_kb->getSelected();
 
-				if (vkb_choice == "auto")
-					vkb_choice = "";
+					if (vkb_choice == "auto")
+						vkb_choice = "";
 
-				SystemConf::getInstance()->set(configName + ".gptokeyb", vkb_choice);
-			});
+					SystemConf::getInstance()->set(configName + ".gptokeyb", vkb_choice);
+				});
 		}
 #endif
 


### PR DESCRIPTION
ES - added feature to select configurable virtual keyboards.

in es_features.cfg if you add "gptokeyb" to the emulator, it will enable this feature.
users will be able to select which keyboard profile to set.
the code will then create a config value so it can be read by any sh scripts to load a different mapping file.

depends on:
https://github.com/EmuELEC/EmuELEC/pull/1289
