### PR TITLE
Emuelec - Savestate - Fix

### DIFF
--- a/es-app/src/SaveState.cpp
+++ b/es-app/src/SaveState.cpp
@@ -72,7 +72,7 @@ std::string SaveState::setupSaveState(FileData* game, const std::string& command
 	std::string cmd = command;
 
 	// Savestate has core information ? Setup correct emulator/core
-	if (slot >= -1 && this->config != nullptr && !config->isActiveConfig(game))
+	if (slot >= -2 && this->config != nullptr && !config->isActiveConfig(game))
 	{
 		cmd = _changeCommandlineArgument(cmd, "-emulator", config->emulator);
 		cmd = _changeCommandlineArgument(cmd, "-core", config->core);

--- a/es-app/src/SaveState.cpp
+++ b/es-app/src/SaveState.cpp
@@ -72,7 +72,11 @@ std::string SaveState::setupSaveState(FileData* game, const std::string& command
 	std::string cmd = command;
 
 	// Savestate has core information ? Setup correct emulator/core
+#ifdef _ENABLEEMUELEC
 	if (slot >= -2 && this->config != nullptr && !config->isActiveConfig(game))
+#else
+	if (slot >= -1 && this->config != nullptr && !config->isActiveConfig(game))
+#endif
 	{
 		cmd = _changeCommandlineArgument(cmd, "-emulator", config->emulator);
 		cmd = _changeCommandlineArgument(cmd, "-core", config->core);

--- a/es-app/src/SaveState.cpp
+++ b/es-app/src/SaveState.cpp
@@ -73,7 +73,7 @@ std::string SaveState::setupSaveState(FileData* game, const std::string& command
 
 	// Savestate has core information ? Setup correct emulator/core
 #ifdef _ENABLEEMUELEC
-	if (slot >= -2 && this->config != nullptr && !config->isActiveConfig(game))
+	if (this->config != nullptr && !config->isActiveConfig(game))
 #else
 	if (slot >= -1 && this->config != nullptr && !config->isActiveConfig(game))
 #endif

--- a/es-app/src/SaveState.cpp
+++ b/es-app/src/SaveState.cpp
@@ -80,6 +80,11 @@ std::string SaveState::setupSaveState(FileData* game, const std::string& command
 		if (!config->core.empty())
 			cmd = _changeCommandlineArgument(cmd, "-core", config->core);
 	}
+
+	if (slot == -1 || slot == -2) {
+		cmd = cmd + " -autoload 0";
+	}
+
 #else
 	if (slot >= -1 && this->config != nullptr && !config->isActiveConfig(game))
 	{

--- a/es-app/src/SaveState.cpp
+++ b/es-app/src/SaveState.cpp
@@ -74,13 +74,20 @@ std::string SaveState::setupSaveState(FileData* game, const std::string& command
 	// Savestate has core information ? Setup correct emulator/core
 #ifdef _ENABLEEMUELEC
 	if (this->config != nullptr && !config->isActiveConfig(game))
+	{
+		if (!config->emulator.empty())
+			cmd = _changeCommandlineArgument(cmd, "-emulator", config->emulator);
+		if (!config->core.empty())
+			cmd = _changeCommandlineArgument(cmd, "-core", config->core);
+	}
 #else
 	if (slot >= -1 && this->config != nullptr && !config->isActiveConfig(game))
-#endif
 	{
 		cmd = _changeCommandlineArgument(cmd, "-emulator", config->emulator);
 		cmd = _changeCommandlineArgument(cmd, "-core", config->core);
 	}	
+
+#endif
 
 	bool supportsIncremental = config != nullptr ? config->incremental : game->getSourceFileData()->getSystem()->getSaveStateRepository()->supportsIncrementalSaveStates();
 

--- a/es-core/src/utils/Platform.cpp
+++ b/es-core/src/utils/Platform.cpp
@@ -179,7 +179,11 @@ namespace Utils
 #ifdef WIN32 // windows
 			return system("shutdown -s -t 0");
 #else // osx / linux	
+#ifdef _ENABLEEMUELEC
+			return system("ee_shutdown.sh");	
+#else
 			return system("shutdown -h now");
+#endif
 #endif
 		}
 


### PR DESCRIPTION
Emuelec - Savestate - Fix

Issue Listed Here:
https://github.com/EmuELEC/EmuELEC/issues/1313

Notes:
Fixes Issue.
For some reason when the config emulator/core are not set the empty variables over-write the arguments, so when loading from a save state, the emulator does not parse the defaults.
The fix was to check if the emular/core variables are not empty and if the are only then over-write the arguments.

Workaround:
I have not tested this but to get it working on the previous code, set the emulator and core in advanced game options and then it may use the config values and run savestates ok.

