### PR TITLE
EE - framebuffer config fixes 

### DIFF
--- a/es-app/src/guis/GuiMenu.h
+++ b/es-app/src/guis/GuiMenu.h
@@ -74,7 +74,7 @@ private:
     static void openDangerZone(Window* mWindow, std::string configName);
     static void createGamepadConfig(Window* window, GuiSettings* systemConfiguration);
     static void openExternalMounts(Window* mWindow, std::string configName);
-		static void addFrameBufferOptions(Window* mWindow, GuiSettings* guiSettings, std::string configName, std::string header);
+		static void addFrameBufferOptions(Window* mWindow, GuiSettings* guiSettings, std::string configName, std::string header, std::string platform);
 #endif
 
 	void openSystemSettings();


### PR DESCRIPTION
EE - framebuffer config fixes 

Currently it's not possible to adjust the frameborder values for specific games. This patch tries to fix that so people can set different framebuffer border for individual games.
