### PR TITLE
Silence warnings

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4773,8 +4773,8 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createJoyBtnRemapOpti
 
 void GuiMenu::editJoyBtnRemapOptionList(Window *window, GuiSettings *systemConfiguration, std::string prefixName)
 {
-	const std::function<void(std::string)> editFunc([window, systemConfiguration, del_choice, edit_choice, prefixName] (std::string remapName) {
-		int editIndex = edit_choice->getSelectedIndex();
+	const std::function<void(std::string)> editFunc([window, systemConfiguration, prefixName] (std::string remapName) {
+		int editIndex = GuiMenu::edit_choice->getSelectedIndex();
 		if (editIndex <= 0)
 			return;
 
@@ -4783,24 +4783,24 @@ void GuiMenu::editJoyBtnRemapOptionList(Window *window, GuiSettings *systemConfi
 		if (!remapName.empty())
 			GuiMenu::createBtnJoyCfgRemap(window, systemConfiguration, prefixName, remapName, 0);
 
-		edit_choice->selectFirstItem();
-		del_choice->selectFirstItem();
+		GuiMenu::edit_choice->selectFirstItem();
+		GuiMenu::del_choice->selectFirstItem();
 
 		window->pushGui(systemConfiguration);
 	});
 
-	edit_choice->setSelectedChangedCallback([window, systemConfiguration, editFunc, edit_choice, del_choice, prefixName](std::string s) {
+	edit_choice->setSelectedChangedCallback([window, systemConfiguration, editFunc, prefixName](std::string s) {
 		long unsigned int m1 = (long unsigned int) &(*window->peekGui());
 		long unsigned int m2 = (long unsigned int) &(*systemConfiguration);
 		if (m1 == m2)
 			return;
 
-		std::string sn = edit_choice->getSelectedName();
+		std::string sn = GuiMenu::edit_choice->getSelectedName();
 		editFunc(sn);
 	});
 
-	systemConfiguration->addSaveFunc([window, systemConfiguration, editFunc, edit_choice, del_choice, prefixName] {
-		std::string sn = edit_choice->getSelectedName();
+	systemConfiguration->addSaveFunc([window, systemConfiguration, editFunc, prefixName] {
+		std::string sn = GuiMenu::edit_choice->getSelectedName();
 		editFunc(sn);
 	});
 }
@@ -4854,7 +4854,7 @@ void GuiMenu::createBtnJoyCfgRemap(Window *window, GuiSettings *systemConfigurat
 	}
 
 
-	systemConfiguration->addSaveFunc([window, systemConfiguration, remap_choice, del_choice, btn_choice, prefixName, remapName, btnCount, orderIndex] {
+	systemConfiguration->addSaveFunc([window, systemConfiguration, remap_choice, prefixName, remapName, btnCount, orderIndex] {
 		// Hack to avoid over-writing defaults.
 		/*if (btnIndex != -1 && editIndex > 0 && editIndex <= 2)
 		{
@@ -4914,7 +4914,7 @@ void GuiMenu::createBtnJoyCfgRemap(Window *window, GuiSettings *systemConfigurat
 		if (orderIndex == -1)
 		{
 			window->pushGui(new GuiMsgBox(window, _("ARE YOU SURE YOU WANT TO CREATE THE REMAP?"),
-				_("YES"), [addRemaps, remap_choice, del_choice, btn_choice, prefixName, remapName, btnCount]
+				_("YES"), [addRemaps, remap_choice, prefixName, remapName, btnCount]
 			{
 				std::string remapNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_remap_names");
 				remapNames = remapNames.empty() ? remapName : (remapNames + "," + remapName);
@@ -5008,8 +5008,8 @@ void GuiMenu::addJoyBtnEntry(std::string name, std::string val) {
 void GuiMenu::deleteBtnJoyCfg(Window *window, GuiSettings *systemConfiguration,
 	 std::string prefixName)
 {
-	const std::function<void()> saveFunc([window, btn_choice, del_choice, edit_choice, prefixName] {
-		int delIndex = del_choice->getSelectedIndex();
+	const std::function<void()> saveFunc([window, prefixName] {
+		int delIndex = GuiMenu::del_choice->getSelectedIndex();
 		int remapIndex = delIndex-1;
 
 		// Protect default maps (mk and sf).
@@ -5017,41 +5017,41 @@ void GuiMenu::deleteBtnJoyCfg(Window *window, GuiSettings *systemConfiguration,
 		{
 			window->pushGui(new GuiMsgBox(window,  _("CANNOT DELETE DEFAULT BUTTON MAPS."),
 				_("OK"), nullptr));
-			del_choice->selectFirstItem();
+			GuiMenu::del_choice->selectFirstItem();
 			return;
 		}
 
 		// Delete does not remove the existing button maps so any game/emulator references will still work.
 		std::string remapNames = SystemConf::getInstance()->get(prefixName + ".joy_btn_remap_names");
 
-		std::string remapName = del_choice->getSelectedName();
+		std::string remapName = GuiMenu::del_choice->getSelectedName();
 		remapNames = Utils::String::replace(remapNames, ","+remapName, "");
 		remapNames = Utils::String::replace(remapNames, remapName+",", "");
 		SystemConf::getInstance()->set(prefixName + ".joy_btn_remap_names", remapNames);
 
 		SystemConf::getInstance()->set(prefixName + ".joy_btn_order."+remapName, "");
 
-		int btnIndex = btn_choice->getSelectedIndex();
+		int btnIndex = GuiMenu::btn_choice->getSelectedIndex();
 		GuiMenu::removeJoyBtnEntry(delIndex);
 
 		if (btnIndex == delIndex)
 			btnIndex = 0;
-		if (btnIndex >= del_choice->size() && del_choice->size() > 0)
+		if (btnIndex >= GuiMenu::del_choice->size() && GuiMenu::del_choice->size() > 0)
 			btnIndex--;
 
-		del_choice->selectFirstItem();
-		edit_choice->selectFirstItem();
-		btn_choice->selectIndex(btnIndex);
+		GuiMenu::del_choice->selectFirstItem();
+		GuiMenu::edit_choice->selectFirstItem();
+		GuiMenu::btn_choice->selectIndex(btnIndex);
 	});
 
 	del_choice->setSelectedChangedCallback(
-		[window, systemConfiguration, saveFunc, btn_choice, del_choice, edit_choice, prefixName] (std::string s) {
+		[window, systemConfiguration, saveFunc, prefixName] (std::string s) {
 		long unsigned int m1 = (long unsigned int) &(*window->peekGui());
 		long unsigned int m2 = (long unsigned int) &(*systemConfiguration);
 		if (m1 == m2)
 			return;
 
-		int delIndex = del_choice->getSelectedIndex();
+		int delIndex = GuiMenu::del_choice->getSelectedIndex();
 		if (delIndex <= 0)
 			return;
 
@@ -5059,8 +5059,8 @@ void GuiMenu::deleteBtnJoyCfg(Window *window, GuiSettings *systemConfiguration,
 			_("YES"), saveFunc, _("NO"), nullptr));
 	});
 
-	systemConfiguration->addSaveFunc([window, saveFunc, btn_choice, del_choice, edit_choice, prefixName] {
-		int delIndex = del_choice->getSelectedIndex();
+	systemConfiguration->addSaveFunc([window, saveFunc, prefixName] {
+		int delIndex = GuiMenu::del_choice->getSelectedIndex();
 		if (delIndex <= 0)
 			return;
 
@@ -5298,8 +5298,8 @@ void GuiMenu::popSpecificConfigurationGui(Window* mWindow, std::string title, st
 			systemConfiguration->addWithLabel(_("EDIT REMAP"), edit_choice);
 			systemConfiguration->addWithLabel(_("DELETE REMAP"), del_choice);
 
-			systemConfiguration->addSaveFunc([btn_choice, configName, prefixName] {
-				std::string remapName = btn_choice->getSelectedName();
+			systemConfiguration->addSaveFunc([configName, prefixName] {
+				std::string remapName = GuiMenu::btn_choice->getSelectedName();
 				if (remapName == "NONE")
 					remapName = "";
 				SystemConf::getInstance()->set(configName + ".joy_btn_index", remapName);				

--- a/es-core/src/HttpReq.cpp
+++ b/es-core/src/HttpReq.cpp
@@ -200,7 +200,7 @@ void HttpReq::performRequest(const std::string& url, HttpReqOptions* options)
 	}
 
 	//set curl restrict redirect protocols
-	err = curl_easy_setopt(mHandle, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS); 
+	err = curl_easy_setopt(mHandle, CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
 	if(err != CURLE_OK)
 	{
 		mStatus = REQ_IO_ERROR;

--- a/es-core/src/components/VideoVlcComponent.cpp
+++ b/es-core/src/components/VideoVlcComponent.cpp
@@ -783,7 +783,14 @@ void VideoVlcComponent::startVideo()
 
 			unsigned track_count;
 			// Get the media metadata so we can find the aspect ratio
+#ifdef WIN32
+			// It looks like an older version of the library is being used on Windows.
 			libvlc_media_parse(mMedia);
+#else
+			libvlc_media_parse_with_options(mMedia, libvlc_media_parse_local, 0);
+			while (libvlc_media_get_parsed_status(mMedia) != libvlc_media_parsed_status_done)
+				std::this_thread::sleep_for(std::chrono::milliseconds(10));
+#endif
 			libvlc_media_track_t** tracks;
 			track_count = libvlc_media_tracks_get(mMedia, &tracks);
 			for (unsigned track = 0; track < track_count; ++track)

--- a/es-core/src/components/WebImageComponent.cpp
+++ b/es-core/src/components/WebImageComponent.cpp
@@ -21,14 +21,14 @@ public:
 		const std::string prot_end("://");
 		std::string::const_iterator prot_i = search(url_s.begin(), url_s.end(), prot_end.begin(), prot_end.end());
 		ret.protocol.reserve(distance(url_s.begin(), prot_i));
-		transform(url_s.begin(), prot_i, back_inserter(ret.protocol), ptr_fun<int, int>(tolower));
+		std::transform(url_s.begin(), prot_i, std::back_inserter(ret.protocol), [](unsigned char c) { return std::tolower(c); });
 		if (prot_i == url_s.end())
 			return ret;
 
 		advance(prot_i, prot_end.length());
 		string::const_iterator path_i = find(prot_i, url_s.end(), '/');
 		ret.host.reserve(distance(prot_i, path_i));
-		transform(prot_i, path_i, back_inserter(ret.host), ptr_fun<int, int>(tolower)); // host is icase
+		std::transform(prot_i, path_i, std::back_inserter(ret.host), [](unsigned char c) { return std::tolower(c); }); // host is icase
 		string::const_iterator query_i = find(path_i, url_s.end(), '?');
 		ret.path.assign(path_i, query_i);
 		if (query_i != url_s.end())

--- a/external/id3v2lib/src/header.c
+++ b/external/id3v2lib/src/header.c
@@ -44,7 +44,14 @@ ID3v2_header* get_tag_header(const char* file_name)
         return NULL;
     }
 
-    fread(buffer, ID3_HEADER, 1, file);
+    size_t bytesRead = fread(buffer, ID3_HEADER, 1, file);
+    if (bytesRead != 1)
+    {
+        perror("Error reading file");
+        fclose(file);
+        return NULL;
+    }
+
     fclose(file);
     return get_tag_header_with_buffer(buffer, ID3_HEADER);
 }

--- a/external/id3v2lib/src/id3v2lib.c
+++ b/external/id3v2lib/src/id3v2lib.c
@@ -43,7 +43,14 @@ ID3v2_tag* load_tag(const char* file_name)
         return NULL;
     }
     //fseek(file, 10, SEEK_SET);
-    fread(buffer, header_size+10, 1, file);
+    size_t bytesRead = fread(buffer, header_size + 10, 1, file);
+    if (bytesRead != 1)
+    {
+        perror("Error reading file");
+        fclose(file);
+        return NULL;
+    }
+
     fclose(file);
 
 
@@ -537,6 +544,12 @@ void tag_set_composer(char* composer, char encoding, ID3v2_tag* tag)
 void tag_set_album_cover(const char* filename, ID3v2_tag* tag)
 {
     FILE* album_cover = fopen(filename, "rb");
+    if (album_cover == NULL)
+    {
+        perror("Error opening file");
+        return;
+    }
+
     char *album_cover_bytes;
     int image_size;
     char *mimetype;
@@ -545,8 +558,22 @@ void tag_set_album_cover(const char* filename, ID3v2_tag* tag)
     image_size = (int) ftell(album_cover);
     fseek(album_cover, 0, SEEK_SET);
 
-    album_cover_bytes = (char*) malloc(image_size * sizeof(char));
-    fread(album_cover_bytes, 1, image_size, album_cover);
+    album_cover_bytes = (char*)malloc(image_size);
+    if (album_cover_bytes == NULL)
+    {
+        perror("Memory allocation failed");
+        fclose(album_cover);
+        return;
+    }
+
+    size_t bytesRead = fread(album_cover_bytes, 1, image_size, album_cover);
+    if (bytesRead != image_size)
+    {
+        perror("Error reading file");
+        free(album_cover_bytes);
+        fclose(album_cover);
+        return;
+    }
 
     fclose(album_cover);
 

--- a/external/libcheevos/cheevos.cpp
+++ b/external/libcheevos/cheevos.cpp
@@ -47,7 +47,7 @@ void rc_hash_handle_file_close(void* file_handle)
 	CHEEVOS_FREE(file_handle);
 }
 
-typedef struct cdreader_trackinfo
+struct cdreader_trackinfo
 {
 	cdreader_trackinfo(bool isChd, void* pointer) { chd = isChd; ptr = pointer; }
 


### PR DESCRIPTION
- Resolved the following warnings  
```
external/id3v2lib/src/header.c:47:5: warning: ignoring return value of ‘fread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
external/id3v2lib/src/id3v2lib.c:46:5: warning: ignoring return value of ‘fread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
external/id3v2lib/src/id3v2lib.c:549:5: warning: ignoring return value of ‘fread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
external/libcheevos/cheevos.cpp:50:1: warning: ‘typedef’ was ignored in this declaration
es-core/src/HttpReq.cpp:203:41: warning: ‘CURLOPT_REDIR_PROTOCOLS’ is deprecated: since 7.85.0. Use CURLOPT_REDIR_PROTOCOLS_STR [-Wdeprecated-declarations]
es-core/src/components/VideoVlcComponent.cpp:786:43: warning: ‘void libvlc_media_parse(libvlc_media_t*)’ is deprecated [-Wdeprecated-declarations]
es-core/src/components/WebImageComponent.cpp:24:96: warning: ‘std::pointer_to_unary_function<_Arg, _Result> std::ptr_fun(_Result (*)(_Arg)) [with _Arg = int; _Result = int]’ is deprecated: use 'std::function' instead [-Wdeprecated-declarations]
es-core/src/components/WebImageComponent.cpp:31:85: warning: ‘std::pointer_to_unary_function<_Arg, _Result> std::ptr_fun(_Result (*)(_Arg)) [with _Arg = int; _Result = int]’ is deprecated: use 'std::function' instead [-Wdeprecated-declarations]
```

from https://github.com/batocera-linux/batocera-emulationstation/pull/1863