### PR TITLE
[Netplay] Try host mode during game startup

### DIFF
--- a/es-app/src/FileData.cpp
+++ b/es-app/src/FileData.cpp
@@ -601,6 +601,12 @@ std::string FileData::getlaunchCommand(LaunchGameOptions& options, bool includeC
 	if (options.netPlayMode != DISABLED && (forceCore || gameToUpdate->isNetplaySupported()) && command.find("%NETPLAY%") == std::string::npos)
 		command = command + " %NETPLAY%"; // Add command line parameter if the netplay option is defined at <core netplay="true"> level
 
+	if (SystemConf::getInstance()->get("global.netplay.nickname").empty())
+	{
+		SystemConf::getInstance()->set("global.netplay.nickname", ApiSystem::getInstance()->getApplicationName() + " Player");
+		SystemConf::getInstance()->saveSystemConf();
+	}
+
 	if (options.netPlayMode == CLIENT || options.netPlayMode == SPECTATOR)
 	{
 		std::string mode = (options.netPlayMode == SPECTATOR ? "spectator" : "client");

--- a/es-app/src/guis/GuiNetPlay.cpp
+++ b/es-app/src/guis/GuiNetPlay.cpp
@@ -500,6 +500,7 @@ bool GuiNetPlay::populateFromJson(const std::string json)
 	}
 
 	std::vector<LobbyAppEntry> entries;
+	entries.reserve(doc.Size());
 
 	for (auto& item : doc.GetArray())
 	{
@@ -593,26 +594,18 @@ bool GuiNetPlay::populateFromJson(const std::string json)
 
 		game.coreExists = coreExists(file, game.core_name);
 
-		entries.push_back(game);
+		entries.push_back(std::move(game));
 	}	
-
-	auto theme = ThemeData::getMenuTheme();
 
 	bool groupAvailable = false;
 
-	struct { bool operator()(LobbyAppEntry& a, LobbyAppEntry& b) const 
-	{ 
-		if (a.isCrcValid == b.isCrcValid)
-			return a.coreExists && !b.coreExists;
+	std::sort(entries.begin(), entries.end(), [](const LobbyAppEntry& a, const LobbyAppEntry& b) {
+		return a.isCrcValid ? !b.isCrcValid : (a.coreExists && !b.coreExists);
+	});
 
-		return a.isCrcValid && !b.isCrcValid;
-	} } sortByValidCrc;
-
-	std::sort(entries.begin(), entries.end(), sortByValidCrc);
-	
 	bool netPlayShowMissingGames = Settings::NetPlayShowMissingGames();
 
-	for (auto game : entries)
+	for (auto& game : entries)
 	{
 		if (game.fileData == nullptr)
 			continue;
@@ -632,14 +625,14 @@ bool GuiNetPlay::populateFromJson(const std::string json)
 		if (game.fileData != nullptr)
 			row.makeAcceptInputHandler([this, game] { launchGame(game); });
 
-		mList->addRow(row);
+		mList->addRow(std::move(row));
 	}
 
 	if (netPlayShowMissingGames)
 	{
 		bool groupUnavailable = false;
 
-		for (auto game : entries)
+		for (auto& game : entries)
 		{
 			if (game.fileData != nullptr)
 				continue;
@@ -652,7 +645,7 @@ bool GuiNetPlay::populateFromJson(const std::string json)
 
 			ComponentListRow row;
 			row.addElement(std::make_shared<NetPlayLobbyListEntry>(mWindow, game), true);
-			mList->addRow(row);
+			mList->addRow(std::move(row));
 		}
 	}
 
@@ -662,7 +655,7 @@ bool GuiNetPlay::populateFromJson(const std::string json)
 		auto empty = std::make_shared<TextComponent>(mWindow);
 		empty->setText(_("NO GAMES FOUND"));
 		row.addElement(empty, true);
-		mList->addRow(row);
+		mList->addRow(std::move(row));
 
 		mGrid.moveCursor(Vector2i(0, 1));
 	}

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -552,6 +552,11 @@ void ViewController::launch(FileData* game, LaunchGameOptions options, Vector3f 
 		}
 		return;
 	}
+
+	if (!SystemConf::getInstance()->getBool("global.netplay") || ApiSystem::getInstance()->getIpAdress() == "NOT CONNECTED" || !game->isNetplaySupported())
+		options.netPlayMode = DISABLED;
+	else if (options.netPlayMode == DISABLED && SystemConf::getInstance()->getBool("global.netplay_public_announce"))
+		options.netPlayMode = SERVER;
 	
 	Transform4x4f origCamera = mCamera;
 	origCamera.translation() = -mCurrentView->getPosition();


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0512f616-0122-4fbf-a742-5bfb652ecf03)
Netplay enabled, and the `netplay_public_announce` is on, try host mode when running the game.
And a default value is set if the netplay.nickname is empty.
ex) EMUELEC Player

This feature is used in TRIMUI, and with its addition, look forward to more players enjoying NetPlay.

Also, Minor performance improvement in populateFromJson.

from https://github.com/batocera-linux/batocera-emulationstation/pull/1862