### PR TITLE
[NetPlay] Add Lan game search in lobby

### DIFF
--- a/es-app/src/guis/GuiNetPlay.h
+++ b/es-app/src/guis/GuiNetPlay.h
@@ -8,9 +8,32 @@
 #include "components/TextComponent.h"
 #include <memory>
 #include <unordered_set>
+#include <vector>
 
 class HttpReq;
 class FileData;
+
+// from RetroArch network/netplay
+#define NETPLAY_NICK_LEN         32
+#define NETPLAY_HOST_STR_LEN     32
+#define NETPLAY_HOST_LONGSTR_LEN 256
+#define DISCOVERY_QUERY_MAGIC    0x52414E51 /* RANQ */
+#define DISCOVERY_RESPONSE_MAGIC 0x52414E53 /* RANS */
+
+struct ad_packet
+{
+	uint32_t header;
+	int32_t  content_crc;
+	int32_t  port;
+	uint32_t has_password;
+	char     nick[NETPLAY_NICK_LEN];
+	char     frontend[NETPLAY_HOST_STR_LEN];
+	char     core[NETPLAY_HOST_STR_LEN];
+	char     core_version[NETPLAY_HOST_STR_LEN];
+	char     retroarch_version[NETPLAY_HOST_STR_LEN];
+	char     content[NETPLAY_HOST_LONGSTR_LEN];
+	char     subsystem_name[NETPLAY_HOST_LONGSTR_LEN];
+};
 
 struct LobbyAppEntry
 {
@@ -45,6 +68,7 @@ class GuiNetPlay : public GuiComponent
 {
 public:
 	GuiNetPlay(Window *window);
+	~GuiNetPlay();
 
 	void update(int deltaTime) override;
 	void render(const Transform4x4f &parentTrans) override;
@@ -57,11 +81,20 @@ public:
 
 private:
 	void startRequest();
+
 	bool populateFromJson(const std::string json);
+	bool populateFromLan();
+
+	bool populateList();
+
 	void launchGame(LobbyAppEntry entry);
+	void lanLobbyRequest();
 
 	FileData* getFileData(const std::string gameInfo, bool crc = true, std::string coreName = "");
 	bool coreExists(FileData* file, std::string core_name);
+
+	int								mLanLobbySocket;
+	int								mLanLobbySocketTimeout;
 
 	NinePatchComponent				mBackground;
 	ComponentGrid					mGrid;
@@ -76,5 +109,8 @@ private:
 
 	BusyComponent					mBusyAnim;
 
-	std::unique_ptr<HttpReq> mLobbyRequest;
+	std::unique_ptr<HttpReq>		mLobbyRequest;
+
+	std::vector<LobbyAppEntry>		mLanEntries;
+	std::vector<LobbyAppEntry>		mLobbyEntries;
 };

--- a/es-app/src/guis/GuiNetPlaySettings.cpp
+++ b/es-app/src/guis/GuiNetPlaySettings.cpp
@@ -21,6 +21,9 @@ GuiNetPlaySettings::GuiNetPlaySettings(Window* window) : GuiSettings(window, _("
 
 	addInputTextRow(_("PORT"), "global.netplay.port", false);
 	addOptionList(_("USE RELAY SERVER"), { { _("NONE"), "" },{ _("NEW YORK") , "nyc" },{ _("MADRID") , "madrid" },{ _("MONTREAL") , "montreal" },{ _("SAO PAULO") , "saopaulo" } }, "global.netplay.relay", false);
+
+	addSwitch(_("AUTOMATICALLY CREATE LOBBY"), _("Automatically creates a Netplay lobby when starting a game."), "NetPlayAutomaticallyCreateLobby", true, nullptr);
+	addSwitch(_("SHOW RELAY SERVER GAMES ONLY"), _("Relay server games have a higher chance of successful entry."), "NetPlayShowOnlyRelayServerGames", true, nullptr);
 	addSwitch(_("SHOW UNAVAILABLE GAMES"), _("Show rooms for games not present on this machine."), "NetPlayShowMissingGames", true, nullptr);
 
 	addGroup(_("GAME INDEXES"));

--- a/es-app/src/views/ViewController.cpp
+++ b/es-app/src/views/ViewController.cpp
@@ -555,7 +555,7 @@ void ViewController::launch(FileData* game, LaunchGameOptions options, Vector3f 
 
 	if (!SystemConf::getInstance()->getBool("global.netplay") || ApiSystem::getInstance()->getIpAdress() == "NOT CONNECTED" || !game->isNetplaySupported())
 		options.netPlayMode = DISABLED;
-	else if (options.netPlayMode == DISABLED && SystemConf::getInstance()->getBool("global.netplay_public_announce"))
+	else if (options.netPlayMode == DISABLED && Settings::getInstance()->getBool("NetPlayAutomaticallyCreateLobby"))
 		options.netPlayMode = SERVER;
 	
 	Transform4x4f origCamera = mCamera;

--- a/es-core/src/HttpReq.cpp
+++ b/es-core/src/HttpReq.cpp
@@ -200,7 +200,11 @@ void HttpReq::performRequest(const std::string& url, HttpReqOptions* options)
 	}
 
 	//set curl restrict redirect protocols
+#if WIN32
+	err = curl_easy_setopt(mHandle, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+#else 
 	err = curl_easy_setopt(mHandle, CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
+#endif
 	if(err != CURLE_OK)
 	{
 		mStatus = REQ_IO_ERROR;

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -372,6 +372,8 @@ void Settings::setDefaults()
 	mIntMap["audio.display_titles_time"] = 10;
 
 	mBoolMap["NetPlayCheckIndexesAtStart"] = false;
+	mBoolMap["NetPlayAutomaticallyCreateLobby"] = false;
+	mBoolMap["NetPlayShowOnlyRelayServerGames"] = false;
 	mBoolMap["NetPlayShowMissingGames"] = false;
 	
 	mBoolMap["CheevosCheckIndexesAtStart"] = false;	

--- a/es-core/src/Settings.h
+++ b/es-core/src/Settings.h
@@ -95,6 +95,8 @@ public:
 	DEFINE_BOOL_SETTING(ThreadedLoading)
 	DEFINE_BOOL_SETTING(CheevosCheckIndexesAtStart)
 	DEFINE_BOOL_SETTING(NetPlayCheckIndexesAtStart)
+	DEFINE_BOOL_SETTING(NetPlayAutomaticallyCreateLobby)
+	DEFINE_BOOL_SETTING(NetPlayShowOnlyRelayServerGames)
 	DEFINE_BOOL_SETTING(NetPlayShowMissingGames)			
 	DEFINE_BOOL_SETTING(LoadEmptySystems)		
 	DEFINE_STRING_SETTING(HiddenSystems)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/54dc172f-ed58-4dc8-b306-ff79b7f0dd8d)

Support browsing RetroArch games in the lobby within the same network.
These games are added to the LAN GAMES group, while games retrieved from lobby.libretro.com are added to the ONLINE GAMES group.

from https://github.com/batocera-linux/batocera-emulationstation/pull/1876