### PR TITLE
Added menu entry for activating and connecting Wiimote IR

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -960,6 +960,12 @@ void GuiMenu::createGamepadConfig(Window* window, GuiSettings* systemConfigurati
 {
 	GuiSettings* gamepadConfiguration = new GuiSettings(window, _("GAMEPAD CONFIG"));
 
+	// Wiimote with IR-Sensorbar
+	
+	s->addEntry(_("ACTIVATE WIIMOTE WITH SENSORBAR"), false, [] {
+            system("/usr/bin/runwiimote.sh");
+    };
+
 	// Advmame Gamepad
 	auto enable_advmamegp = std::make_shared<SwitchComponent>(window);
 	bool advgpEnabled = SystemConf::getInstance()->get("advmame_auto_gamepad") == "1";
@@ -4911,11 +4917,7 @@ void GuiMenu::openQuitMenu_static(Window *window, bool quickAccessMenu, bool ani
 			}, _("NO"), nullptr));
 		}, "iconControllers");
 		
-		s->addEntry(_("KILL LIBRESPOT"), false, [] {
-            system("/emuelec/scripts/librekill.sh");
-        }, "iconLibrekill");
-
-		
+			
 		s->addEntry(_("REBOOT FROM NAND"), false, [window] {
 			window->pushGui(new GuiMsgBox(window, _("REALLY REBOOT FROM NAND?"), _("YES"),
 				[] {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -960,36 +960,22 @@ void GuiMenu::createGamepadConfig(Window* window, GuiSettings* systemConfigurati
 {
 	GuiSettings* gamepadConfiguration = new GuiSettings(window, _("GAMEPAD CONFIG"));
 
-#include <thread>
-#include <chrono>
+// Wiimote Connection Script Launcher
 
-// Wiimote Connection Script Launcher (asynchronously with a short delay)
 gamepadConfiguration->addEntry(_("ACTIVATE WIIMOTE CONNECTION"), false, [window] {
-    // Immediately show an instruction popup.
+    // Zeige zuerst den Hinweis und führe die Verbindung erst nach "OK" aus
     window->pushGui(new GuiMsgBox(window,
-        _("Please ensure your Wiimote is in pairing mode (hold buttons 1+2).\nConnecting..."),
-        _("OK")));
-
-    // Launch the pairing script in a background thread after a short delay
-    std::thread([window]() {
-        // Give the GUI time to update the popup (adjust delay if necessary)
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-        // Call the pairing script (this will block until the pairing process completes)
-        int result = system("/storage/.config/emuelec/bin/connectbtwii.sh");
-
-        // After the pairing script returns, display the result.
-        // (Note: if your framework requires GUI calls to be made on the main thread,
-        // consider dispatching this call to the main thread appropriately.)
-        if(result == 0)
-            window->pushGui(new GuiMsgBox(window,
-                _("Wiimote successfully connected."),
-                _("OK")));
-        else
-            window->pushGui(new GuiMsgBox(window,
-                _("Error while running connectbtwii.sh."),
-                _("OK")));
-    }).detach();
+        _("Please ensure your Wiimote is in pairing mode (hold buttons 1+2).\n\nPress OK to start connection."),
+        _("OK"),
+        [window] {
+            // Jetzt ist die MessageBox schon sichtbar gewesen – jetzt verbinden
+            int result = system("/storage/.config/emuelec/bin/connectbtwii.sh");
+            
+            if(result == 0)
+                window->pushGui(new GuiMsgBox(window, _("Wiimote successfully connected."), _("OK")));
+            else
+                window->pushGui(new GuiMsgBox(window, _("Error while running connectbtwii.sh."), _("OK")));
+        }));
 });
 
 	

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -960,6 +960,16 @@ void GuiMenu::createGamepadConfig(Window* window, GuiSettings* systemConfigurati
 {
 	GuiSettings* gamepadConfiguration = new GuiSettings(window, _("GAMEPAD CONFIG"));
 
+	// Wiimote Connection Script Launcher
+gamepadConfiguration->addEntry(_("ACTIVATE WIIMOTE CONNECTION"), false, [window] {
+    int result = system("/storage/.config/emuelec/bin/connectbtwii.sh &");
+    if(result == 0)
+        window->pushGui(new GuiMsgBox(window, _("Wiimote successfully activated."), _("OK")));
+    else
+        window->pushGui(new GuiMsgBox(window, _("Error while running connectbtwii.sh."), _("OK")));
+});
+
+	
 	// Wiimote with IR-Sensorbar
 	gamepadConfiguration->addEntry(_("ACTIVATE WIIMOTE WITH IR-SENSORBAR"), false, [window] {
     int result = system("/usr/bin/runwiimote.sh &");

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -960,22 +960,37 @@ void GuiMenu::createGamepadConfig(Window* window, GuiSettings* systemConfigurati
 {
 	GuiSettings* gamepadConfiguration = new GuiSettings(window, _("GAMEPAD CONFIG"));
 
-// Wiimote Connection Script Launcher (synchron)
+#include <thread>
+#include <chrono>
 
+// Wiimote Connection Script Launcher (asynchronously with a short delay)
 gamepadConfiguration->addEntry(_("ACTIVATE WIIMOTE CONNECTION"), false, [window] {
-    // Immediately show a dialog telling the user to put the Wiimote in pairing mode.
-    window->pushGui(new GuiMsgBox(window, _("Please ensure your Wiimote is in pairing mode (hold buttons 1+2).\nConnecting, please wait..."), _("OK")));
-    
-    // Perform a blocking call; the GUI will freeze until the pairing completes.
-    int result = system("/storage/.config/emuelec/bin/connectbtwii.sh");
-    
-    if(result == 0)
-        window->pushGui(new GuiMsgBox(window, _("Wiimote successfully connected."), _("OK")));
-    else
-        window->pushGui(new GuiMsgBox(window, _("Error while running connectbtwii.sh."), _("OK")));
+    // Immediately show an instruction popup.
+    window->pushGui(new GuiMsgBox(window,
+        _("Please ensure your Wiimote is in pairing mode (hold buttons 1+2).\nConnecting..."),
+        _("OK")));
+
+    // Launch the pairing script in a background thread after a short delay
+    std::thread([window]() {
+        // Give the GUI time to update the popup (adjust delay if necessary)
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        // Call the pairing script (this will block until the pairing process completes)
+        int result = system("/storage/.config/emuelec/bin/connectbtwii.sh");
+
+        // After the pairing script returns, display the result.
+        // (Note: if your framework requires GUI calls to be made on the main thread,
+        // consider dispatching this call to the main thread appropriately.)
+        if(result == 0)
+            window->pushGui(new GuiMsgBox(window,
+                _("Wiimote successfully connected."),
+                _("OK")));
+        else
+            window->pushGui(new GuiMsgBox(window,
+                _("Error while running connectbtwii.sh."),
+                _("OK")));
+    }).detach();
 });
-
-
 
 	
 	// Wiimote with IR-Sensorbar

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -961,10 +961,10 @@ void GuiMenu::createGamepadConfig(Window* window, GuiSettings* systemConfigurati
 	GuiSettings* gamepadConfiguration = new GuiSettings(window, _("GAMEPAD CONFIG"));
 
 	// Wiimote with IR-Sensorbar
-	
 	s->addEntry(_("ACTIVATE WIIMOTE WITH SENSORBAR"), false, [] {
-            system("/usr/bin/runwiimote.sh");
-    };
+    system("/usr/bin/runwiimote.sh");
+	});
+
 
 	// Advmame Gamepad
 	auto enable_advmamegp = std::make_shared<SwitchComponent>(window);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -961,9 +961,12 @@ void GuiMenu::createGamepadConfig(Window* window, GuiSettings* systemConfigurati
 	GuiSettings* gamepadConfiguration = new GuiSettings(window, _("GAMEPAD CONFIG"));
 
 // Wiimote Connection Script Launcher (synchron)
+
 gamepadConfiguration->addEntry(_("ACTIVATE WIIMOTE CONNECTION"), false, [window] {
-     window->pushGui(new GuiMsgBox(window, _("Please ensure your Wiimote is in pairing mode (hold buttons 1+2).\nConnecting, please wait..."), _("OK")));
+    // Immediately show a dialog telling the user to put the Wiimote in pairing mode.
+    window->pushGui(new GuiMsgBox(window, _("Please ensure your Wiimote is in pairing mode (hold buttons 1+2).\nConnecting, please wait..."), _("OK")));
     
+    // Perform a blocking call; the GUI will freeze until the pairing completes.
     int result = system("/storage/.config/emuelec/bin/connectbtwii.sh");
     
     if(result == 0)
@@ -971,6 +974,7 @@ gamepadConfiguration->addEntry(_("ACTIVATE WIIMOTE CONNECTION"), false, [window]
     else
         window->pushGui(new GuiMsgBox(window, _("Error while running connectbtwii.sh."), _("OK")));
 });
+
 
 
 	

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4923,8 +4923,7 @@ void GuiMenu::openQuitMenu_static(Window *window, bool quickAccessMenu, bool ani
 				Utils::Platform::quitES(Utils::Platform::QuitMode::QUIT);
 			}, _("NO"), nullptr));
 		}, "iconControllers");
-		
-			
+				
 		s->addEntry(_("REBOOT FROM NAND"), false, [window] {
 			window->pushGui(new GuiMsgBox(window, _("REALLY REBOOT FROM NAND?"), _("YES"),
 				[] {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -60,11 +60,6 @@
 #include "TextToSpeech.h"
 #include "Paths.h"
 
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <unistd.h>
-#include <signal.h>
-
 #if WIN32
 #include "Win32ApiSystem.h"
 #endif
@@ -966,53 +961,15 @@ void GuiMenu::createGamepadConfig(Window* window, GuiSettings* systemConfigurati
 	GuiSettings* gamepadConfiguration = new GuiSettings(window, _("GAMEPAD CONFIG"));
 
 	// Wiimote with IR-Sensorbar
-	
-
-auto enable_wiimote = std::make_shared<SwitchComponent>(mWindow);
-bool wiimoteEnabled = SystemConf::getInstance()->get("ee_wiimote.enabled") == "1";
-enable_wiimote->setState(wiimoteEnabled);
-s->addWithLabel(_("WIIMOTE WITH IR-SENSORBAR"), enable_wiimote);
-
-s->addSaveFunc([enable_wiimote, window] {
-    bool wiimoteEnabled = enable_wiimote->getState();
-    // Speichere den neuen Zustand in der Systemkonfiguration
-    SystemConf::getInstance()->set("ee_wiimote.enabled", wiimoteEnabled ? "1" : "0");
-
-    // Statische Variable, um die Prozess-ID zwischen den Aufrufen beizubehalten.
-    static pid_t wiimote_pid = -1;
-
-    if (wiimoteEnabled) {
-        // Wenn der Prozess noch nicht läuft, starte ihn.
-        if (wiimote_pid <= 0) {
-            pid_t pid = fork();
-            if (pid == 0) {  // Kindprozess: Ersetze diesen durch das Skript
-                execl("/usr/bin/runwiimote.sh", "runwiimote.sh", (char*)NULL);
-                // Sollte execl fehlschlagen, beenden wir den Kindprozess:
-                exit(1);
-            }
-            else if (pid > 0) {
-                // Elternprozess: Speichere die PID für zukünftige Referenz
-                wiimote_pid = pid;
-            }
-            else {
-                // Bei einem Fork-Fehler: Hier könnte man eine Fehlermeldung oder Logging einfügen
-            }
-        }
-    }
-    else {
-        // Wenn der Switch deaktiviert wurde, und ein Prozess läuft, beenden wir ihn.
-        if (wiimote_pid > 0) {
-            kill(wiimote_pid, SIGTERM);  // Sende SIGTERM zur sanften Beendigung
-            int status;
-            waitpid(wiimote_pid, &status, 0);  // Warte auf den Prozess, um Zombie-Prozesse zu vermeiden
-            wiimote_pid = -1;
-        }
-    }
-    SystemConf::getInstance()->saveSystemConf();
+	gamepadConfiguration->addEntry(_("ACTIVATE WIIMOTE WITH IR-SENSORBAR"), false, [window] {
+    int result = system("/usr/bin/runwiimote.sh &");
+    if(result == 0)
+        window->pushGui(new GuiMsgBox(window, _("Wiimote IR activated."), _("OK")));
+    else
+        window->pushGui(new GuiMsgBox(window, _("Error while running script."), _("OK")));
 });
 
-
-
+});
 
 
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -964,12 +964,12 @@ void GuiMenu::createGamepadConfig(Window* window, GuiSettings* systemConfigurati
 	gamepadConfiguration->addEntry(_("ACTIVATE WIIMOTE WITH IR-SENSORBAR"), false, [window] {
     int result = system("/usr/bin/runwiimote.sh &");
     if(result == 0)
-        window->pushGui(new GuiMsgBox(window, _("Wiimote IR activated."), _("OK")));
+        window->pushGui(new GuiMsgBox(window, _("Wiimote activated."), _("OK")));
     else
         window->pushGui(new GuiMsgBox(window, _("Error while running script."), _("OK")));
 });
 
-});
+
 
 
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -960,14 +960,18 @@ void GuiMenu::createGamepadConfig(Window* window, GuiSettings* systemConfigurati
 {
 	GuiSettings* gamepadConfiguration = new GuiSettings(window, _("GAMEPAD CONFIG"));
 
-	// Wiimote Connection Script Launcher
+// Wiimote Connection Script Launcher (synchron)
 gamepadConfiguration->addEntry(_("ACTIVATE WIIMOTE CONNECTION"), false, [window] {
-    int result = system("/storage/.config/emuelec/bin/connectbtwii.sh &");
+     window->pushGui(new GuiMsgBox(window, _("Please ensure your Wiimote is in pairing mode (hold buttons 1+2).\nConnecting, please wait..."), _("OK")));
+    
+    int result = system("/storage/.config/emuelec/bin/connectbtwii.sh");
+    
     if(result == 0)
-        window->pushGui(new GuiMsgBox(window, _("Wiimote successfully activated."), _("OK")));
+        window->pushGui(new GuiMsgBox(window, _("Wiimote successfully connected."), _("OK")));
     else
         window->pushGui(new GuiMsgBox(window, _("Error while running connectbtwii.sh."), _("OK")));
 });
+
 
 	
 	// Wiimote with IR-Sensorbar

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -962,12 +962,14 @@ void GuiMenu::createGamepadConfig(Window* window, GuiSettings* systemConfigurati
 
 	// Wiimote with IR-Sensorbar
 	gamepadConfiguration->addEntry(_("ACTIVATE WIIMOTE WITH IR-SENSORBAR"), false, [window] {
-    int result = system("/usr/bin/runwiimote.sh");
+    int result = system("/usr/bin/runwiimote.sh &");
     if(result == 0)
         window->pushGui(new GuiMsgBox(window, _("Wiimote activated."), _("OK")));
     else
         window->pushGui(new GuiMsgBox(window, _("Error while running script."), _("OK")));
 });
+
+
 
 
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -961,7 +961,7 @@ void GuiMenu::createGamepadConfig(Window* window, GuiSettings* systemConfigurati
 	GuiSettings* gamepadConfiguration = new GuiSettings(window, _("GAMEPAD CONFIG"));
 
 	// Wiimote with IR-Sensorbar
-	s->addEntry(_("ACTIVATE WIIMOTE WITH SENSORBAR"), false, [] {
+	gamepadConfiguration->addEntry(_("ACTIVATE WIIMOTE WITH SENSORBAR"), false, [] {
     system("/usr/bin/runwiimote.sh");
 	});
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -60,6 +60,11 @@
 #include "TextToSpeech.h"
 #include "Paths.h"
 
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <signal.h>
+
 #if WIN32
 #include "Win32ApiSystem.h"
 #endif
@@ -961,13 +966,51 @@ void GuiMenu::createGamepadConfig(Window* window, GuiSettings* systemConfigurati
 	GuiSettings* gamepadConfiguration = new GuiSettings(window, _("GAMEPAD CONFIG"));
 
 	// Wiimote with IR-Sensorbar
-	gamepadConfiguration->addEntry(_("ACTIVATE WIIMOTE WITH IR-SENSORBAR"), false, [window] {
-    int result = system("/usr/bin/runwiimote.sh &");
-    if(result == 0)
-        window->pushGui(new GuiMsgBox(window, _("Wiimote activated."), _("OK")));
-    else
-        window->pushGui(new GuiMsgBox(window, _("Error while running script."), _("OK")));
+	
+
+auto enable_wiimote = std::make_shared<SwitchComponent>(mWindow);
+bool wiimoteEnabled = SystemConf::getInstance()->get("ee_wiimote.enabled") == "1";
+enable_wiimote->setState(wiimoteEnabled);
+s->addWithLabel(_("WIIMOTE WITH IR-SENSORBAR"), enable_wiimote);
+
+s->addSaveFunc([enable_wiimote, window] {
+    bool wiimoteEnabled = enable_wiimote->getState();
+    // Speichere den neuen Zustand in der Systemkonfiguration
+    SystemConf::getInstance()->set("ee_wiimote.enabled", wiimoteEnabled ? "1" : "0");
+
+    // Statische Variable, um die Prozess-ID zwischen den Aufrufen beizubehalten.
+    static pid_t wiimote_pid = -1;
+
+    if (wiimoteEnabled) {
+        // Wenn der Prozess noch nicht läuft, starte ihn.
+        if (wiimote_pid <= 0) {
+            pid_t pid = fork();
+            if (pid == 0) {  // Kindprozess: Ersetze diesen durch das Skript
+                execl("/usr/bin/runwiimote.sh", "runwiimote.sh", (char*)NULL);
+                // Sollte execl fehlschlagen, beenden wir den Kindprozess:
+                exit(1);
+            }
+            else if (pid > 0) {
+                // Elternprozess: Speichere die PID für zukünftige Referenz
+                wiimote_pid = pid;
+            }
+            else {
+                // Bei einem Fork-Fehler: Hier könnte man eine Fehlermeldung oder Logging einfügen
+            }
+        }
+    }
+    else {
+        // Wenn der Switch deaktiviert wurde, und ein Prozess läuft, beenden wir ihn.
+        if (wiimote_pid > 0) {
+            kill(wiimote_pid, SIGTERM);  // Sende SIGTERM zur sanften Beendigung
+            int status;
+            waitpid(wiimote_pid, &status, 0);  // Warte auf den Prozess, um Zombie-Prozesse zu vermeiden
+            wiimote_pid = -1;
+        }
+    }
+    SystemConf::getInstance()->saveSystemConf();
 });
+
 
 
 

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -961,9 +961,14 @@ void GuiMenu::createGamepadConfig(Window* window, GuiSettings* systemConfigurati
 	GuiSettings* gamepadConfiguration = new GuiSettings(window, _("GAMEPAD CONFIG"));
 
 	// Wiimote with IR-Sensorbar
-	gamepadConfiguration->addEntry(_("ACTIVATE WIIMOTE WITH SENSORBAR"), false, [] {
-    system("/usr/bin/runwiimote.sh");
-	});
+	gamepadConfiguration->addEntry(_("ACTIVATE WIIMOTE WITH IR-SENSORBAR"), false, [window] {
+    int result = system("/usr/bin/runwiimote.sh");
+    if(result == 0)
+        window->pushGui(new GuiMsgBox(window, _("Wiimote activated."), _("OK")));
+    else
+        window->pushGui(new GuiMsgBox(window, _("Error while running script."), _("OK")));
+});
+
 
 
 	// Advmame Gamepad

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -960,23 +960,24 @@ void GuiMenu::createGamepadConfig(Window* window, GuiSettings* systemConfigurati
 {
 	GuiSettings* gamepadConfiguration = new GuiSettings(window, _("GAMEPAD CONFIG"));
 
-// Wiimote Connection Script Launcher
+	// Wiimote bluetooth connection Script
 
-gamepadConfiguration->addEntry(_("ACTIVATE WIIMOTE CONNECTION"), false, [window] {
-    // Zeige zuerst den Hinweis und führe die Verbindung erst nach "OK" aus
+	gamepadConfiguration->addEntry(_("ACTIVATE WIIMOTE CONNECTION"), false, [window] {
+    // Show an initial message asking the user to put the Wiimote in pairing mode
     window->pushGui(new GuiMsgBox(window,
-        _("Please ensure your Wiimote is in pairing mode (hold buttons 1+2).\n\nPress OK to start connection."),
+        _("Please ensure your Wiimote is in pairing mode (hold buttons 1+2).\n\nPress OK to start the connection."),
         _("OK"),
         [window] {
-            // Jetzt ist die MessageBox schon sichtbar gewesen – jetzt verbinden
-            int result = system("/storage/.config/emuelec/bin/connectbtwii.sh");
-            
-            if(result == 0)
+            // Start pairing only after the message box has been shown and dismissed
+            int result = system("/usr/bin/connectbtwii.sh");
+
+            if (result == 0)
                 window->pushGui(new GuiMsgBox(window, _("Wiimote successfully connected."), _("OK")));
             else
                 window->pushGui(new GuiMsgBox(window, _("Error while running connectbtwii.sh."), _("OK")));
         }));
 });
+
 
 	
 	// Wiimote with IR-Sensorbar


### PR DESCRIPTION
1. Pairing the wiimote via bluetooth is not working right now properly in EmuELEC as the pairing process is disturbed by lircd and the wiimote gets recognized, but not trusted and connected in the end. The script "connectbtwii.sh" takes care of that issue and can be executed by the menu entry under gamepad config.

2. In order to make a Nintendo Wiimote work with just a IR sensor (or candle) without the need of using a dolphin bar, a script needs to be started in the background that creates a virtual device for the IR-coordinates. 
(See: https://github.com/EmuELEC/EmuELEC/pull/1500)

The "runwiimote.sh"-script can be started via the menu.

