### PR TITLE
EE - EmuELEC Settings - Sound Settings - audio volume - fixes

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4650,6 +4650,12 @@ void GuiMenu::openSoundSettings()
 
 		// volume
 		auto volume = std::make_shared<SliderComponent>(mWindow, 0.f, 100.f, 1.f, "%");
+#ifndef _ENABLEEMUELEC
+		std::string cfgAudioVolume = SystemConf::getInstance()->get("audio.volume");
+		if (!cfgAudioVolume.empty()) {
+			VolumeControl::getInstance()->setVolume((int)atoi(cfgAudioVolume.c_str()));
+		}
+#endif
 		volume->setValue((float)VolumeControl::getInstance()->getVolume());
 		volume->setOnValueChanged([](const float &newVal) { VolumeControl::getInstance()->setVolume((int)Math::round(newVal)); });
 		s->addWithLabel(_("SYSTEM VOLUME"), volume);
@@ -4658,6 +4664,9 @@ void GuiMenu::openSoundSettings()
 			VolumeControl::getInstance()->setVolume((int)Math::round(volume->getValue()));
 #if !WIN32
 			SystemConf::getInstance()->set("audio.volume", std::to_string((int)round(volume->getValue())));
+#endif
+#ifndef _ENABLEEMUELEC
+			SystemConf::getInstance()->saveSystemConf();
 #endif
 		});
 


### PR DESCRIPTION
EE - EmuELEC Settings - Sound Settings - audio volume - fixes

Fixes some issue with audio volume not saving properly and loading the values correctly.

See related Issue:
https://github.com/EmuELEC/EmuELEC/issues/1198

Related Emuelec PR:
https://github.com/EmuELEC/EmuELEC/pull/1507

Tested can commit.
