### PR TITLE
Automatic shutdown function after user inactivity

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -31,6 +31,8 @@
 #include <SDL_events.h>
 #include <algorithm>
 #include "utils/Platform.h"
+#include "utils/StringUtil.h"
+
 
 
 #include "SystemConf.h"
@@ -4891,10 +4893,9 @@ void GuiMenu::openQuitMenu_static(Window *window, bool quickAccessMenu, bool ani
 	s->addEntry(_("RESTART EMULATIONSTATION"), false, [window] {
 		window->pushGui(new GuiMsgBox(window, _("REALLY RESTART EMULATIONSTATION?"), _("YES"),
 			[] {
-    		   /*Utils::Platform::ProcessStartInfo("systemctl restart emustation.service", "", nullptr);*/
-    		   Scripting::fireEvent("quit", "restart");
-			   Utils::Platform::quitES(Utils::Platform::QuitMode::QUIT);
-		}, _("NO"), nullptr));
+				Scripting::fireEvent("quit", "restart");
+				Utils::Platform::quitES(Utils::Platform::QuitMode::QUIT);
+			}, _("NO"), nullptr));
 	}, "iconRestart");
 
 	bool isFullUI = UIModeController::getInstance()->isUIModeFull();
@@ -4903,31 +4904,46 @@ void GuiMenu::openQuitMenu_static(Window *window, bool quickAccessMenu, bool ani
 		s->addEntry(_("START RETROARCH"), false, [window] {
 			window->pushGui(new GuiMsgBox(window, _("REALLY START RETROARCH?"), _("YES"),
 				[] {
-				remove("/var/lock/start.games");
-				Utils::Platform::ProcessStartInfo("touch /var/lock/start.retro").run();
-				Utils::Platform::ProcessStartInfo("systemctl start retroarch.service").run();
-				Scripting::fireEvent("quit", "retroarch");
-				Utils::Platform::quitES(Utils::Platform::QuitMode::QUIT);
-			}, _("NO"), nullptr));
+					remove("/var/lock/start.games");
+					Utils::Platform::ProcessStartInfo("touch /var/lock/start.retro").run();
+					Utils::Platform::ProcessStartInfo("systemctl start retroarch.service").run();
+					Scripting::fireEvent("quit", "retroarch");
+					Utils::Platform::quitES(Utils::Platform::QuitMode::QUIT);
+				}, _("NO"), nullptr));
 		}, "iconControllers");
-		
-		s->addEntry(_("KILL LIBRESPOT"), false, [] {
-            system("/emuelec/scripts/librekill.sh");
-        }, "iconLibrekill");
 
-		
 		s->addEntry(_("REBOOT FROM NAND"), false, [window] {
 			window->pushGui(new GuiMsgBox(window, _("REALLY REBOOT FROM NAND?"), _("YES"),
 				[] {
-				Scripting::fireEvent("quit", "nand");
-				Utils::Platform::ProcessStartInfo("rebootfromnand").run();
-				Utils::Platform::ProcessStartInfo("sync").run();
-				Utils::Platform::ProcessStartInfo("systemctl reboot").run();
-				Utils::Platform::quitES(Utils::Platform::QuitMode::QUIT);
-			}, _("NO"), nullptr));
+					Scripting::fireEvent("quit", "nand");
+					Utils::Platform::ProcessStartInfo("rebootfromnand").run();
+					Utils::Platform::ProcessStartInfo("sync").run();
+					Utils::Platform::ProcessStartInfo("systemctl reboot").run();
+					Utils::Platform::quitES(Utils::Platform::QuitMode::QUIT);
+				}, _("NO"), nullptr));
 		}, "iconAdvanced");
 	}
+
+	// AUTO SHUTDOWN TIMEOUT 
+	auto shutdownSlider = std::make_shared<SliderComponent>(window, 0.0f, 1440.0f, 10.0f, "min");
+
+	int timeout = 0;
+	try {
+		timeout = std::stoi(SystemConf::getInstance()->get("ee_auto_shutdown_timeout"));
+	} catch (...) {
+		timeout = 0;
+	}
+	shutdownSlider->setValue((float)timeout);
+	s->addWithLabel(_("AUTOMATIC SHUTDOWN AFTER INACTIVITY"), shutdownSlider);
+
+	s->addSaveFunc([shutdownSlider] {
+		int value = (int)shutdownSlider->getValue();
+		SystemConf::getInstance()->set("ee_auto_shutdown_timeout", std::to_string(value));
+		SystemConf::getInstance()->saveSystemConf();
+	});
+
 #endif
+
 
 	if (quickAccessMenu)
 		s->addGroup(_("QUIT"));

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -32,9 +32,6 @@
 #include <algorithm>
 #include "utils/Platform.h"
 #include "utils/StringUtil.h"
-
-
-
 #include "SystemConf.h"
 #include "ApiSystem.h"
 #include "InputManager.h"
@@ -4943,7 +4940,6 @@ void GuiMenu::openQuitMenu_static(Window *window, bool quickAccessMenu, bool ani
 	});
 
 #endif
-
 
 	if (quickAccessMenu)
 		s->addGroup(_("QUIT"));

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -679,6 +679,7 @@ int main(int argc, char* argv[])
 #ifdef WIN32	
 		int processStart = SDL_GetTicks();
 #endif
+
 SDL_Event event;
 
 bool ps_standby = PowerSaver::getState() && (int) SDL_GetTicks() - ps_time > PowerSaver::getMode();
@@ -757,25 +758,47 @@ else if (wasSleeping)
 }
 
 		// Auto-Shutdown Check (every 10 seconds)
-		if (autoShutdownTimeoutMin > 0 && (curTime - lastShutdownCheck) >= 10000) // 10 seconds
-		{
-			lastShutdownCheck = curTime;
-			
-			unsigned long now = (unsigned long)time(nullptr);
-			unsigned long timeoutSec = autoShutdownTimeoutMin * 60;
-			unsigned long inactiveTime = now - lastInputTime;
+		if ((curTime - lastShutdownCheck) >= 10000) // 10 seconds
+{
+	lastShutdownCheck = curTime;
 
-			if (inactiveTime >= timeoutSec)
-			{
-				Utils::Platform::quitES(Utils::Platform::QuitMode::SHUTDOWN);
-				running = false; 
-			}
-			else if ((timeoutSec - inactiveTime) <= 60) 
-			{
-				unsigned long remainingTime = (timeoutSec - inactiveTime);
-				
-			}
+		// Dynamically reload the timeout value from emuelec.conf
+	int autoShutdownTimeoutMin = 0;
+	std::string confTimeoutStr = SystemConf::getInstance()->get("ee_auto_shutdown_timeout");
+	if (!confTimeoutStr.empty())
+	{
+		try {
+			autoShutdownTimeoutMin = std::stoi(confTimeoutStr);
+			if (autoShutdownTimeoutMin < 0) autoShutdownTimeoutMin = 0;
+		} catch (...) {
+			LOG(LogError) << "[AutoShutdown] Invalid value in ee_auto_shutdown_timeout: " << confTimeoutStr;
+			autoShutdownTimeoutMin = 0;
 		}
+	}
+
+	if (autoShutdownTimeoutMin > 0)
+	{
+		unsigned long now = (unsigned long)time(nullptr);
+		unsigned long timeoutSec = autoShutdownTimeoutMin * 60;
+		unsigned long inactiveTime = now - lastInputTime;
+
+		if (inactiveTime >= timeoutSec)
+		{
+			LOG(LogInfo) << "[AutoShutdown] Inactivity timeout reached ("
+						<< autoShutdownTimeoutMin << " min, "
+						<< (inactiveTime / 60) << " min inactive). Shutting down system...";
+			Utils::Platform::quitES(Utils::Platform::QuitMode::SHUTDOWN);
+			running = false;
+		}
+		else if ((timeoutSec - inactiveTime) <= 60)
+		{
+			unsigned long remainingTime = (timeoutSec - inactiveTime);
+			LOG(LogInfo) << "[AutoShutdown] Warning: System will shut down in "
+						<< remainingTime << " seconds due to inactivity.";
+		}
+	}
+}
+
 
 		TRYCATCH("Window.update" ,window.update(deltaTime))	
 		TRYCATCH("Window.render", window.render())

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -298,7 +298,7 @@ bool loadSystemConfigFile(Window* window, const char** errorString)
 		LOG(LogError) << "No systems found! Does at least one system have a game present? (check that extensions match!)\n(Also, make sure you've updated your es_systems.cfg for XML!)";
 		*errorString = "WE CAN'T FIND ANY SYSTEMS!\n"
 			"CHECK THAT YOUR PATHS ARE CORRECT IN THE SYSTEMS CONFIGURATION FILE, "
-			"AND YOUR GAME DIRECTORY HAS AT LEAST ONE GAME WITH THE CORRECT EXTENSION.\n\n"
+			"AND YOUR GAME directory HAS AT LEAST ONE GAME WITH THE CORRECT EXTENSION.\n\n"
 			"VISIT EMULATIONSTATION.ORG FOR MORE INFORMATION.";
 		return false;
 	}
@@ -649,8 +649,28 @@ int main(int argc, char* argv[])
 		timeLimit = 0;
 #endif
 
+	// load auto-shutdown configuration from emuelec.conf
+	int autoShutdownTimeoutMin = 0;
+	std::string confTimeoutStr = SystemConf::getInstance()->get("ee_auto_shutdown_timeout");
+	if (!confTimeoutStr.empty())
+	{
+		try {
+			autoShutdownTimeoutMin = std::stoi(confTimeoutStr);
+			if (autoShutdownTimeoutMin < 0) autoShutdownTimeoutMin = 0;
+		} catch (...) {
+			LOG(LogError) << "[AutoShutdown] Invalid value in ee_auto_shutdown_timeout: " << confTimeoutStr;
+			autoShutdownTimeoutMin = 0;
+		}
+		
+		if (autoShutdownTimeoutMin > 0) {
+			LOG(LogInfo) << "[AutoShutdown] auto-shutdown activated: " << autoShutdownTimeoutMin << " minutes of inactivity";
+		}
+	}
+
 	int lastTime = SDL_GetTicks();
 	int ps_time = SDL_GetTicks();
+	unsigned long lastInputTime = (unsigned long)time(nullptr);
+	unsigned int lastShutdownCheck = SDL_GetTicks();
 
 	bool running = true;
 
@@ -659,52 +679,67 @@ int main(int argc, char* argv[])
 #ifdef WIN32	
 		int processStart = SDL_GetTicks();
 #endif
+SDL_Event event;
 
-		SDL_Event event;
+bool ps_standby = PowerSaver::getState() && (int) SDL_GetTicks() - ps_time > PowerSaver::getMode();
+if (ps_standby ? SDL_WaitEventTimeout(&event, PowerSaver::getTimeout()) : SDL_PollEvent(&event))
+{
+	// PowerSaver can push events to exit SDL_WaitEventTimeout immediatly
+	// Reset this event's state
+	TRYCATCH("resetRefreshEvent", PowerSaver::resetRefreshEvent());
 
-		bool ps_standby = PowerSaver::getState() && (int) SDL_GetTicks() - ps_time > PowerSaver::getMode();
-		if(ps_standby ? SDL_WaitEventTimeout(&event, PowerSaver::getTimeout()) : SDL_PollEvent(&event))
+	do
+	{
+		TRYCATCH("InputManager::parseEvent", InputManager::getInstance()->parseEvent(event, &window));
+
+		
+		if (event.type == SDL_KEYDOWN ||
+			event.type == SDL_CONTROLLERBUTTONDOWN ||
+			event.type == SDL_JOYBUTTONDOWN ||
+			event.type == SDL_MOUSEBUTTONDOWN ||
+			event.type == SDL_MOUSEMOTION)
 		{
-			// PowerSaver can push events to exit SDL_WaitEventTimeout immediatly
-			// Reset this event's state
-			TRYCATCH("resetRefreshEvent", PowerSaver::resetRefreshEvent());
-
-			do
-			{
-				TRYCATCH("InputManager::parseEvent", InputManager::getInstance()->parseEvent(event, &window));
-
-				if (event.type == SDL_QUIT)
-					running = false;
-			} 
-			while(SDL_PollEvent(&event));
-
-			// check guns
-			InputManager::getInstance()->updateGuns(&window);
-
-			// triggered if exiting from SDL_WaitEvent due to event
-			if (ps_standby)
-				// show as if continuing from last event
-				lastTime = SDL_GetTicks();
-
-			// reset counter
-			ps_time = SDL_GetTicks();
-		}
-		else if (ps_standby == false)
-		{
-		  // check guns
-		  InputManager::getInstance()->updateGuns(&window);
-
-		  // If exitting SDL_WaitEventTimeout due to timeout. Trail considering
-		  // timeout as an event
-		  //	ps_time = SDL_GetTicks();
+			lastInputTime = (unsigned long)time(nullptr);
 		}
 
-		if (window.isSleeping())
-		{
-			lastTime = SDL_GetTicks();
-			SDL_Delay(1); // this doesn't need to be accurate, we're just giving up our CPU time until something wakes us up
-			continue;
-		}
+		if (event.type == SDL_QUIT)
+			running = false;
+
+	} while(SDL_PollEvent(&event));  
+
+	// check guns
+	InputManager::getInstance()->updateGuns(&window);
+
+	// triggered if exiting from SDL_WaitEvent due to event
+	if (ps_standby)
+		lastTime = SDL_GetTicks();
+
+	// reset counter
+	ps_time = SDL_GetTicks();
+}
+else if (!ps_standby)
+{
+	// check guns
+	InputManager::getInstance()->updateGuns(&window);
+}
+
+
+	static bool wasSleeping = false;
+
+if (window.isSleeping())
+{
+	wasSleeping = true;
+	lastTime = SDL_GetTicks();
+	SDL_Delay(1);
+	continue;
+}
+else if (wasSleeping)
+{
+	// user has exited the emulator
+	lastInputTime = (unsigned long)time(nullptr);
+	wasSleeping = false;
+}
+
 
 		int curTime = SDL_GetTicks();
 		int deltaTime = curTime - lastTime;
@@ -713,6 +748,34 @@ int main(int argc, char* argv[])
 		// cap deltaTime if it ever goes negative
 		if(deltaTime < 0)
 			deltaTime = 1000;
+		
+		// Check for return-from-game signal from emuelecRunEmu.sh
+		if (Utils::FileSystem::exists("/tmp/es_return_from_game"))
+{
+		lastInputTime = (unsigned long)time(nullptr);
+		Utils::FileSystem::removeFile("/tmp/es_return_from_game");
+}
+
+		// Auto-Shutdown Check (every 10 seconds)
+		if (autoShutdownTimeoutMin > 0 && (curTime - lastShutdownCheck) >= 10000) // 10 seconds
+		{
+			lastShutdownCheck = curTime;
+			
+			unsigned long now = (unsigned long)time(nullptr);
+			unsigned long timeoutSec = autoShutdownTimeoutMin * 60;
+			unsigned long inactiveTime = now - lastInputTime;
+
+			if (inactiveTime >= timeoutSec)
+			{
+				Utils::Platform::quitES(Utils::Platform::QuitMode::SHUTDOWN);
+				running = false; 
+			}
+			else if ((timeoutSec - inactiveTime) <= 60) 
+			{
+				unsigned long remainingTime = (timeoutSec - inactiveTime);
+				
+			}
+		}
 
 		TRYCATCH("Window.update" ,window.update(deltaTime))	
 		TRYCATCH("Window.render", window.render())
@@ -760,6 +823,7 @@ int main(int argc, char* argv[])
 #ifdef FREEIMAGE_LIB
 	FreeImage_DeInitialise();
 #endif
+	
 	
 	// Delete ViewController
 	while (window.peekGui() != nullptr)


### PR DESCRIPTION
This PR also needs the files from https://github.com/EmuELEC/EmuELEC/pull/1508

1. Added shutdown function in main.cpp that reads the value of "ee_auto_shutdown_timeout" in emuelec.conf (and shuts down emuelec after the set amount of minutes (even when the screensaver is running).

2. Added a slider-menu entry ("AUTOMATIC SHUTDOWN AFTER INACTIVITY") in GuiMenu.cpp where the user can easily set the amount of minutes until shutdown (in 10 minutes steps).
