### PR TITLE
EmuELEC - emulationstation - [Feature] EmuELEC Settings - Danger Zone - ES/RA Arguments 

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1346,6 +1346,27 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		addFrameBufferOptions(mWindow, dangerZone, "ee_es", "ES", "");
 		addFrameBufferOptions(mWindow, dangerZone, "", "EMU", "");
 
+    dangerZone->addEntry(_("CLOUD BACKUP SETTINGS AND GAME SAVES"), true, [mWindow] {
+    mWindow->pushGui(new GuiMsgBox(mWindow, _("WARNING THIS WILL RESTART EMULATIONSTATION!\n\nThis will backup your game saves, savestates and emuelec configs to the cloud service configured on rclone.conf\n\nBACKUP TO CLOUD AND RESTART?"), _("YES"),
+				[] { 
+				Utils::Platform::ProcessStartInfo("systemd-run /usr/bin/emuelec-utils ee_cloud_backup backup").run();
+				}, _("NO"), nullptr));
+     });
+
+    dangerZone->addEntry(_("CLOUD RESTORE SETTINGS AND GAME SAVES"), true, [mWindow] { 
+    mWindow->pushGui(new GuiMsgBox(mWindow, _("WARNING THIS WILL RESTART EMULATIONSTATION!\n\nThis will restore your game saves, savestates and emuelec configs from the cloud service configured on rclone.conf, it will overwrite any existing file!!\n\nRESTORE FROM CLOUD AND RESTART?"), _("YES"),
+				[] { 
+				Utils::Platform::ProcessStartInfo("systemd-run /usr/bin/emuelec-utils ee_cloud_backup restore").run();
+				}, _("NO"), nullptr));
+     });
+
+    dangerZone->addEntry(_("LOCAL BACKUP EMUELEC CONFIGS"), true, [mWindow] { 
+    mWindow->pushGui(new GuiMsgBox(mWindow, _("WARNING THIS WILL RESTART EMULATIONSTATION!\n\nAFTER THE SCRIPT IS DONE REMEMBER TO COPY THE FILE /storage/roms/backup/ee_backup_config.tar.gz TO SOME PLACE!\n\nBACKUP CURRENT CONFIG AND RESTART?"), _("YES"),
+				[] { 
+				Utils::Platform::ProcessStartInfo("systemd-run /usr/bin/emuelec-utils ee_backup backup").run();
+				}, _("NO"), nullptr));
+     });
+
 #ifdef _ENABLEEMUELEC
 		dangerZone->addEntry(_("ADD EMUSTATION ARGUMENTS"), true, [mWindow] {
 			std::string argsFilename = "/emuelec/configs/ES_ARGS";
@@ -1387,27 +1408,6 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 				mWindow->pushGui(new GuiTextEditPopup(mWindow, _("ADD RETROARCH ARGUMENTS"), fileText, updateVal, false));
 		 });
 #endif
-
-    dangerZone->addEntry(_("CLOUD BACKUP SETTINGS AND GAME SAVES"), true, [mWindow] {
-    mWindow->pushGui(new GuiMsgBox(mWindow, _("WARNING THIS WILL RESTART EMULATIONSTATION!\n\nThis will backup your game saves, savestates and emuelec configs to the cloud service configured on rclone.conf\n\nBACKUP TO CLOUD AND RESTART?"), _("YES"),
-				[] { 
-				Utils::Platform::ProcessStartInfo("systemd-run /usr/bin/emuelec-utils ee_cloud_backup backup").run();
-				}, _("NO"), nullptr));
-     });
-
-    dangerZone->addEntry(_("CLOUD RESTORE SETTINGS AND GAME SAVES"), true, [mWindow] { 
-    mWindow->pushGui(new GuiMsgBox(mWindow, _("WARNING THIS WILL RESTART EMULATIONSTATION!\n\nThis will restore your game saves, savestates and emuelec configs from the cloud service configured on rclone.conf, it will overwrite any existing file!!\n\nRESTORE FROM CLOUD AND RESTART?"), _("YES"),
-				[] { 
-				Utils::Platform::ProcessStartInfo("systemd-run /usr/bin/emuelec-utils ee_cloud_backup restore").run();
-				}, _("NO"), nullptr));
-     });
-
-    dangerZone->addEntry(_("LOCAL BACKUP EMUELEC CONFIGS"), true, [mWindow] { 
-    mWindow->pushGui(new GuiMsgBox(mWindow, _("WARNING THIS WILL RESTART EMULATIONSTATION!\n\nAFTER THE SCRIPT IS DONE REMEMBER TO COPY THE FILE /storage/roms/backup/ee_backup_config.tar.gz TO SOME PLACE!\n\nBACKUP CURRENT CONFIG AND RESTART?"), _("YES"),
-				[] { 
-				Utils::Platform::ProcessStartInfo("systemd-run /usr/bin/emuelec-utils ee_backup backup").run();
-				}, _("NO"), nullptr));
-     });
 
     dangerZone->addEntry(_("RESET EMUELEC SCRIPTS AND BINARIES TO DEFAULT"), true, [mWindow] { 
     mWindow->pushGui(new GuiMsgBox(mWindow, _("WARNING: SYSTEM WILL RESET SCRIPTS AND BINARIES !\nUPDATE, DOWNLOADS, THEMES, BLUETOOTH PAIRINGS AND ROMS FOLDER WILL NOT BE AFFECTED.\n\nRESET SCRIPTS AND BINARIES TO DEFAULT AND RESTART?"), _("YES"),

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1372,13 +1372,11 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			std::string argsFilename = "/emuelec/configs/ES_ARGS";
 			auto updateVal = [argsFilename](const std::string& newVal)
 			{
-				if (newVal.empty())
-					return;
-
 				if (Utils::FileSystem::exists(argsFilename))
 					Utils::FileSystem::removeFile(argsFilename);
 
-				Utils::FileSystem::writeAllText(argsFilename, newVal);
+				if (!newVal.empty())
+					Utils::FileSystem::writeAllText(argsFilename, newVal);
 			};
 
 			std::string fileText = Utils::FileSystem::readAllText(argsFilename);
@@ -1392,13 +1390,11 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			std::string argsFilename = "/emuelec/configs/RA_ARGS";
 			auto updateVal = [argsFilename](const std::string& newVal)
 			{
-				if (newVal.empty())
-					return;
-
 				if (Utils::FileSystem::exists(argsFilename))
 					Utils::FileSystem::removeFile(argsFilename);
 
-				Utils::FileSystem::writeAllText(argsFilename, newVal);
+				if (!newVal.empty())
+					Utils::FileSystem::writeAllText(argsFilename, newVal);
 			};
 
 			std::string fileText = Utils::FileSystem::readAllText(argsFilename);

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1347,8 +1347,6 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		addFrameBufferOptions(mWindow, dangerZone, "", "EMU", "");
 
 #ifdef _ENABLEEMUELEC
-
-
 		dangerZone->addEntry(_("ADD EMUSTATION ARGUMENTS"), true, [mWindow] {
 			std::string argsFilename = "/emuelec/configs/ES_ARGS";
 			auto updateVal = [argsFilename](const std::string& newVal)
@@ -1388,7 +1386,6 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 			else
 				mWindow->pushGui(new GuiTextEditPopup(mWindow, _("ADD RETROARCH ARGUMENTS"), fileText, updateVal, false));
 		 });
-
 #endif
 
     dangerZone->addEntry(_("CLOUD BACKUP SETTINGS AND GAME SAVES"), true, [mWindow] {

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -1346,7 +1346,52 @@ void GuiMenu::openDangerZone(Window* mWindow, std::string configName)
 		addFrameBufferOptions(mWindow, dangerZone, "ee_es", "ES", "");
 		addFrameBufferOptions(mWindow, dangerZone, "", "EMU", "");
 
-    dangerZone->addEntry(_("CLOUD BACKUP SETTINGS AND GAME SAVES"), true, [mWindow] { 
+#ifdef _ENABLEEMUELEC
+
+
+		dangerZone->addEntry(_("ADD EMUSTATION ARGUMENTS"), true, [mWindow] {
+			std::string argsFilename = "/emuelec/configs/ES_ARGS";
+			auto updateVal = [argsFilename](const std::string& newVal)
+			{
+				if (newVal.empty())
+					return;
+
+				if (Utils::FileSystem::exists(argsFilename))
+					Utils::FileSystem::removeFile(argsFilename);
+
+				Utils::FileSystem::writeAllText(argsFilename, newVal);
+			};
+
+			std::string fileText = Utils::FileSystem::readAllText(argsFilename);
+			if (Settings::getInstance()->getBool("UseOSK"))
+				mWindow->pushGui(new GuiTextEditPopupKeyboard(mWindow, _("ADD EMUSTATION ARGUMENTS"), fileText, updateVal, false));
+			else
+				mWindow->pushGui(new GuiTextEditPopup(mWindow, _("ADD EMUSTATION ARGUMENTS"), fileText, updateVal, false));
+		 });
+
+		dangerZone->addEntry(_("ADD RETROARCH ARGUMENTS"), true, [mWindow] {
+			std::string argsFilename = "/emuelec/configs/RA_ARGS";
+			auto updateVal = [argsFilename](const std::string& newVal)
+			{
+				if (newVal.empty())
+					return;
+
+				if (Utils::FileSystem::exists(argsFilename))
+					Utils::FileSystem::removeFile(argsFilename);
+
+				Utils::FileSystem::writeAllText(argsFilename, newVal);
+			};
+
+			std::string fileText = Utils::FileSystem::readAllText(argsFilename);
+			if (Settings::getInstance()->getBool("UseOSK"))
+				mWindow->pushGui(new GuiTextEditPopupKeyboard(mWindow, _("ADD RETROARCH ARGUMENTS"), fileText, updateVal, false));
+			else
+				mWindow->pushGui(new GuiTextEditPopup(mWindow, _("ADD RETROARCH ARGUMENTS"), fileText, updateVal, false));
+		 });
+
+#endif
+
+    dangerZone->addEntry(_("CLOUD BACKUP SETTINGS AND GAME SAVES"), true, [mWindow] {
     mWindow->pushGui(new GuiMsgBox(mWindow, _("WARNING THIS WILL RESTART EMULATIONSTATION!\n\nThis will backup your game saves, savestates and emuelec configs to the cloud service configured on rclone.conf\n\nBACKUP TO CLOUD AND RESTART?"), _("YES"),
 				[] { 
 				Utils::Platform::ProcessStartInfo("systemd-run /usr/bin/emuelec-utils ee_cloud_backup backup").run();


### PR DESCRIPTION
EmuELEC - emulationstation - [Feature] EmuELEC Settings - Danger Zone - ES/RA Arguments 

Allows the user to add emulationstation and retroarch arguments to a file which are then loaded when the services start execution.

Dependent on PR:
https://github.com/EmuELEC/EmuELEC/pull/1506

