### PR TITLE
Automatic shutdown function after user inactivity

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -32,7 +32,9 @@
 #include <algorithm>
 #include "utils/Platform.h"
 
-
+#ifdef _ENABLEEMUELEC
+	#include "utils/StringUtil.h"
+#endif
 #include "SystemConf.h"
 #include "ApiSystem.h"
 #include "InputManager.h"
@@ -4910,10 +4912,6 @@ void GuiMenu::openQuitMenu_static(Window *window, bool quickAccessMenu, bool ani
 				Utils::Platform::quitES(Utils::Platform::QuitMode::QUIT);
 			}, _("NO"), nullptr));
 		}, "iconControllers");
-		
-		s->addEntry(_("KILL LIBRESPOT"), false, [] {
-            system("/emuelec/scripts/librekill.sh");
-        }, "iconLibrekill");
 
 		
 		s->addEntry(_("REBOOT FROM NAND"), false, [window] {
@@ -4927,6 +4925,25 @@ void GuiMenu::openQuitMenu_static(Window *window, bool quickAccessMenu, bool ani
 			}, _("NO"), nullptr));
 		}, "iconAdvanced");
 	}
+
+	// AUTO SHUTDOWN TIMEOUT
+	auto shutdownSlider = std::make_shared<SliderComponent>(window, 0.0f, 1440.0f, 10.0f, "min");
+
+	int timeout = 0;
+	try {
+		timeout = std::stoi(SystemConf::getInstance()->get("ee_auto_shutdown_timeout"));
+	} catch (...) {
+		timeout = 0;
+	}
+	shutdownSlider->setValue((float)timeout);
+	s->addWithLabel(_("AUTOMATIC SHUTDOWN AFTER INACTIVITY"), shutdownSlider);
+
+	s->addSaveFunc([shutdownSlider] {
+		int value = (int)shutdownSlider->getValue();
+		SystemConf::getInstance()->set("ee_auto_shutdown_timeout", std::to_string(value));
+		SystemConf::getInstance()->saveSystemConf();
+	});
+
 #endif
 
 	if (quickAccessMenu)


### PR DESCRIPTION
This PR also needs the files from https://github.com/EmuELEC/EmuELEC/pull/1508

Added shutdown function in main.cpp that reads the value of "ee_auto_shutdown_timeout" in emuelec.conf (and shuts down emuelec after the set amount of minutes (even when the screensaver is running).

Added a slider-menu entry ("AUTOMATIC SHUTDOWN AFTER INACTIVITY") in GuiMenu.cpp where the user can easily set the amount of minutes until shutdown (in 10 minutes steps).