### PR TITLE
Added menu entry for activating and connecting Wiimote IR

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -962,6 +962,34 @@ void GuiMenu::createGamepadConfig(Window* window, GuiSettings* systemConfigurati
 {
 	GuiSettings* gamepadConfiguration = new GuiSettings(window, _("GAMEPAD CONFIG"));
 
+#ifdef _ENABLEEMUELEC
+	// Wiimote bluetooth connection Script
+	gamepadConfiguration->addEntry(_("ACTIVATE WIIMOTE CONNECTION"), false, [window] {
+    // Show an initial message asking the user to put the Wiimote in pairing mode
+    window->pushGui(new GuiMsgBox(window,
+        _("Please ensure your Wiimote is in pairing mode (hold buttons 1+2).\n\nPress OK to start the connection."),
+        _("OK"),
+        [window] {
+            // Start pairing only after the message box has been shown and dismissed
+            int result = system("/usr/bin/connectbtwii.sh");
+
+            if (result == 0)
+                window->pushGui(new GuiMsgBox(window, _("Wiimote successfully connected."), _("OK")));
+            else
+                window->pushGui(new GuiMsgBox(window, _("Error while running connectbtwii.sh."), _("OK")));
+        }));
+});
+
+	// Wiimote with IR-Sensorbar
+	gamepadConfiguration->addEntry(_("ACTIVATE WIIMOTE WITH IR-SENSORBAR"), false, [window] {
+    int result = system("/usr/bin/runwiimote.sh &");
+    if(result == 0)
+        window->pushGui(new GuiMsgBox(window, _("Wiimote activated."), _("OK")));
+    else
+        window->pushGui(new GuiMsgBox(window, _("Error while running script."), _("OK")));
+});
+#endif
+
 	// Advmame Gamepad
 	auto enable_advmamegp = std::make_shared<SwitchComponent>(window);
 	bool advgpEnabled = SystemConf::getInstance()->get("advmame_auto_gamepad") == "1";


### PR DESCRIPTION
1. Pairing the wiimote via bluetooth is not working right now properly in EmuELEC as the pairing process is disturbed by lircd and the wiimote gets recognized, but not trusted and connected in the end. The script "connectbtwii.sh" takes care of that issue and can be executed by the menu entry ("ACTIVATE WIIMOTE CONNECTION") under gamepad config.

2. In order to make a Nintendo Wiimote work with just a IR sensor (or candle) without the need of using a dolphin bar, a script needs to be started in the background that creates a virtual device for the IR-coordinates.
(See: https://github.com/EmuELEC/EmuELEC/pull/1500)

3. The "runwiimote.sh"-script can be started via the menu-entry "ACTIVATE WIIMOTE WITH IR-SENSORBAR".