### PR TITLE
Added ability to display icon within the addWithLabel function

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -4983,8 +4983,8 @@ void GuiMenu::openQuitMenu_static(Window *window, bool quickAccessMenu, bool ani
 		timeout = 0;
 	}
 	shutdownSlider->setValue((float)timeout);
-	s->addWithLabel(_("AUTOMATIC SHUTDOWN AFTER INACTIVITY"), shutdownSlider);
-
+	s->addWithLabel(_("AUTOMATIC SHUTDOWN AFTER INACTIVITY"),
+    shutdownSlider, nullptr, "iconAutoShutdown");
 	s->addSaveFunc([shutdownSlider] {
 		int value = (int)shutdownSlider->getValue();
 		SystemConf::getInstance()->set("ee_auto_shutdown_timeout", std::to_string(value));

--- a/es-app/src/guis/GuiSettings.h
+++ b/es-app/src/guis/GuiSettings.h
@@ -31,10 +31,24 @@ public:
 		mMenu.addRow(row); 
 	}
 
-	inline void addWithLabel(const std::string& label, const std::shared_ptr<GuiComponent>& comp, bool setCursorHere = false) 
-	{ 
-		mMenu.addWithLabel(label, comp, nullptr, "", setCursorHere); 
-	}
+	// Old call remains compatible
+	inline void addWithLabel(const std::string& label,
+    const std::shared_ptr<GuiComponent>& comp,
+    bool setCursorHere = false)
+{
+    addWithLabel(label, comp, nullptr, "", setCursorHere);
+}
+
+	// New overload with icon and optional callback
+	inline void addWithLabel(const std::string& label,
+    const std::shared_ptr<GuiComponent>& comp,
+    const std::function<void()>& callback,
+    const std::string& iconName,
+    bool setCursorHere = false)
+{
+    mMenu.addWithLabel(label, comp, callback, iconName, setCursorHere);
+}
+
 
 	inline void addWithDescription(const std::string& label, const std::string& description, const std::shared_ptr<GuiComponent>& comp, bool setCursorHere = false) 
 	{ 

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -643,6 +643,7 @@ std::map<std::string, std::map<std::string, ThemeData::ElementPropertyType>> The
 		{ "iconNetwork", PATH },
 		{ "iconScraper", PATH },
 		{ "iconAdvanced", PATH },
+		{ "iconAutoShutdown", PATH },
 		{ "iconQuit", PATH } } },
 	{ "menuSwitch",{
 		{ "pathOn", PATH },


### PR DESCRIPTION
1. Added new functionality to also display icons attached to the "addWithLabel"-function inside GuiSettings.h

2. Added "iconAutoShutdown" to the Automatic Shutdown-entry inside GuiMenu.cpp

3. Added "iconAutoShutdown"-variable inside ThemeData.cpp

4. In order to display an icon in front of the "Automatic Shutdown"-entry in the menu, a png called "AutoShutdown.png" must be put both inside the "\\emuelec\Emulationstation Config\themes\Crystal\assets\menu_icons\dark" and "\\emuelec\Emulationstation Config\themes\Crystal\assets\menu_icons\light"-folders 

and

also the entry "<iconAutoShutdown>./assets/menu_icons/${cmenuicons}/AutoShutdown.png</iconAutoShutdown>" has to be added inside the "\\emuelec\Emulationstation Config\themes\Crystal\theme.xml"-file under the  "<menuIcons name="menuicons">" section

See attached screenshot for clarification.