### PR TITLE
Added preview option for custom splash images and videos

### DIFF
--- a/es-app/src/guis/GuiFileBrowser.cpp
+++ b/es-app/src/guis/GuiFileBrowser.cpp
@@ -2,10 +2,6 @@
 
 #include "ApiSystem.h"
 #include "components/OptionListComponent.h"
-#include "components/ImageComponent.h"
-#include "components/BusyComponent.h"
-#include "resources/TextureResource.h"
-#include "utils/StringUtil.h"
 #include "guis/GuiSettings.h"
 #include "views/ViewController.h"
 #include "components/ComponentGrid.h"
@@ -16,9 +12,15 @@
 #include <cstring>
 #include "SystemConf.h"
 #include "Paths.h"
+#ifdef _ENABLEEMUELEC
+#include "components/ImageComponent.h"
+#include "components/BusyComponent.h"
+#include "resources/TextureResource.h"
+#include "utils/StringUtil.h"
 #include "utils/Platform.h"
 #include "utils/FileSystemUtil.h"
 #include <algorithm>
+#endif
 
 #define WINDOW_WIDTH (float)Math::max((int)Renderer::getScreenHeight(), (int)(Renderer::getScreenWidth() * 0.65f))
 
@@ -32,7 +34,7 @@
 
 
 GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types, const std::function<void(const std::string&)>& okCallback, const std::string& title)
-        : GuiComponent(window), mMenu(window, title.empty() ? _("FILE BROWSER") : title)
+    : GuiComponent(window), mMenu(window, title.empty() ? _("FILE BROWSER") : title)
 {
 	setTag("popup");
 
@@ -40,31 +42,27 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 	mSelectedFile = Utils::FileSystem::getCanonicalPath(selectedFile);
 	mOkCallback = okCallback;
 
-        addChild(&mMenu);
-
+    addChild(&mMenu);
+#ifdef _ENABLEEMUELEC
        mPreview = std::make_shared<ImageComponent>(window);
        mPreview->setVisible(false);
        mPreview->setAllowFading(false);
        addChild(mPreview.get());
-
        mLoadingBg = std::make_shared<ImageComponent>(window);
        mLoadingBg->setVisible(false);
        mLoadingBg->setImage(":/white.png");
        mLoadingBg->setColorShift(0x000000FF);
        addChild(mLoadingBg.get());
-
        mLoading = std::make_shared<BusyComponent>(window);
        mLoading->setVisible(false);
        mLoading->setBackgroundVisible(false);
        addChild(mLoading.get());
-
        mCurrentFrame = 0;
        mFrameTime = 0;
        mGeneratingPreview = false;
        mExpectedFrames = 0;
        mLastFrameCount = 0;
        mNoFrameTime = 0;
-
        mMenu.getList()->setCursorChangedCallback([this](CursorState state)
        {
                if (mMenu.size() == 0)
@@ -74,7 +72,6 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
                        clearVideoPreview();
                        return;
                }
-
                std::string path = mMenu.getSelected();
                std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(path));
                if (ext == ".jpg" || ext == ".png" || ext == ".gif" || ext == ".svg")
@@ -94,7 +91,7 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
                        mPreview->setVisible(false);
                }
        });
-
+#endif
 	if (mOkCallback != nullptr)
 	{
 		mMenu.addButton(_("RESET"), "back", [&]
@@ -114,31 +111,26 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 		navigateTo(mCurrentPath);
 	}
 	else
-               navigateTo(startPath);
+        navigateTo(startPath);
+#ifdef _ENABLEEMUELEC
 }
-
 GuiFileBrowser::~GuiFileBrowser()
 {
        clearVideoPreview();
 }
-
 void GuiFileBrowser::update(int deltaTime)
 {
        GuiComponent::update(deltaTime);
-
        if (mGeneratingPreview)
        {
                auto files = Utils::FileSystem::getDirectoryFiles(mTempPreviewDir);
                files.sort([](const Utils::FileSystem::FileInfo& a, const Utils::FileSystem::FileInfo& b) { return a.path < b.path; });
-
                for (auto file : files)
                {
                        if (file.directory)
                                continue;
-
                        if (Utils::String::toLower(Utils::FileSystem::getExtension(file.path)) != ".png")
                                continue;
-
                        if (std::find(mVideoFrames.begin(), mVideoFrames.end(), file.path) == mVideoFrames.end())
                        {
                                mVideoFrames.push_back(file.path);
@@ -146,7 +138,6 @@ void GuiFileBrowser::update(int deltaTime)
                                mFrameTextures.push_back(TextureResource::get(file.path, false, true, true));
                        }
                }
-
                if ((int)mVideoFrames.size() >= mExpectedFrames)
                        mGeneratingPreview = false;
                else if ((int)mVideoFrames.size() == mLastFrameCount)
@@ -161,7 +152,6 @@ void GuiFileBrowser::update(int deltaTime)
                        mNoFrameTime = 0;
                }
        }
-
        if (!mGeneratingPreview && !mFrameTextures.empty() && !mPreview->isVisible())
        {
                mPreview->setImage(mFrameTextures[0]);
@@ -169,7 +159,6 @@ void GuiFileBrowser::update(int deltaTime)
                mLoading->setVisible(false);
                mLoadingBg->setVisible(false);
        }
-
        if (mPreview->isVisible() && !mFrameTextures.empty())
        {
                mFrameTime += deltaTime;
@@ -181,7 +170,7 @@ void GuiFileBrowser::update(int deltaTime)
                }
        }
 }
-
+#endif
 void GuiFileBrowser::navigateTo(const std::string path)
 {
 	mCurrentPath = path;
@@ -265,17 +254,18 @@ void GuiFileBrowser::navigateTo(const std::string path)
 		}
 	}
 
-        centerWindow();
-
+    centerWindow();
+#ifdef _ENABLEEMUELEC
         if (mMenu.size() > 0 && mMenu.getList()->getCursorChangedCallback())
                 mMenu.getList()->getCursorChangedCallback()(CURSOR_STOPPED);
+#endif
 }
 
 void GuiFileBrowser::centerWindow()
 {
+#ifdef _ENABLEEMUELEC
         float previewWidth = Renderer::getScreenWidth() * 0.3f;
         float menuWidth = Renderer::getScreenWidth() - previewWidth;
-
         if (Renderer::ScreenSettings::fullScreenMenus())
         {
                 mMenu.setSize(menuWidth, Renderer::getScreenHeight());
@@ -286,31 +276,23 @@ void GuiFileBrowser::centerWindow()
        mMenu.setSize(menuWidth, Renderer::getScreenHeight() * 0.875f);
        mMenu.setPosition((Renderer::getScreenWidth() - (menuWidth + previewWidth)) / 2, (Renderer::getScreenHeight() - mMenu.getSize().y()) / 2);
        }
-
        mPreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
        mPreview->setMaxSize(previewWidth, mMenu.getSize().y());
-
        mLoadingBg->setPosition(mPreview->getPosition());
        mLoadingBg->setSize(previewWidth, mMenu.getSize().y());
-
        mLoading->setPosition(mPreview->getPosition());
        mLoading->setSize(previewWidth, mMenu.getSize().y());
-}
-
-void GuiFileBrowser::generateVideoPreview(const std::string& path)
+}void GuiFileBrowser::generateVideoPreview(const std::string& path)
 {
        clearVideoPreview();
-
        mTempPreviewDir = Utils::FileSystem::getTempPath() + "/videopreview";
        Utils::FileSystem::createDirectory(mTempPreviewDir);
-
        std::string command = "ffmpeg -hide_banner -loglevel error -y -i \"" + path +
                "\" -t 5 -vf \"fps=10,scale=720:480:force_original_aspect_ratio=decrease\" \"" +
                mTempPreviewDir + "/frame_%03d.png\"";
        Utils::Platform::ProcessStartInfo psi(command);
        psi.waitForExit = false;
        psi.run();
-
        mGeneratingPreview = true;
        mExpectedFrames = 50;
        mLastFrameCount = 0;
@@ -321,23 +303,17 @@ void GuiFileBrowser::generateVideoPreview(const std::string& path)
        mPreview->setVisible(false);
        mLoadingBg->setVisible(true);
        mLoading->setVisible(true);
-}
-
-void GuiFileBrowser::clearVideoPreview()
+}void GuiFileBrowser::clearVideoPreview()
 {
        mGeneratingPreview = false;
-
 #ifndef WIN32
        Utils::Platform::ProcessStartInfo kill("killall -q ffmpeg");
        kill.run();
 #endif
-
        for (auto& img : mVideoFrames)
                Utils::FileSystem::removeFile(img);
-
        if (!mTempPreviewDir.empty())
                Utils::FileSystem::removeDirectory(mTempPreviewDir);
-
        mVideoFrames.clear();
        mFrameTextures.clear();
        mTempPreviewDir.clear();
@@ -348,7 +324,7 @@ void GuiFileBrowser::clearVideoPreview()
        mLastFrameCount = 0;
        mNoFrameTime = 0;
 }
-
+#endif
 bool GuiFileBrowser::input(InputConfig* config, Input input)
 {
 	if (GuiComponent::input(config, input))

--- a/es-app/src/guis/GuiFileBrowser.cpp
+++ b/es-app/src/guis/GuiFileBrowser.cpp
@@ -2,6 +2,8 @@
 
 #include "ApiSystem.h"
 #include "components/OptionListComponent.h"
+#include "components/ImageComponent.h"
+#include "utils/StringUtil.h"
 #include "guis/GuiSettings.h"
 #include "views/ViewController.h"
 #include "components/ComponentGrid.h"
@@ -34,7 +36,34 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 	mSelectedFile = Utils::FileSystem::getCanonicalPath(selectedFile);
 	mOkCallback = okCallback;
 
-	addChild(&mMenu);
+        addChild(&mMenu);
+
+        mPreview = std::make_shared<ImageComponent>(window);
+       mPreview->setVisible(false);
+       addChild(mPreview.get());
+
+       mMenu.getList()->setCursorChangedCallback([this](CursorState state)
+       {
+               if (mMenu.size() == 0)
+               {
+                       mPreview->setImage("");
+                       mPreview->setVisible(false);
+                       return;
+               }
+
+               std::string path = mMenu.getSelected();
+               std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(path));
+               if (ext == ".jpg" || ext == ".png" || ext == ".gif" || ext == ".svg")
+               {
+                       mPreview->setImage(path);
+                       mPreview->setVisible(true);
+               }
+               else
+               {
+                       mPreview->setImage("");
+                       mPreview->setVisible(false);
+               }
+       });
 
 	if (mOkCallback != nullptr)
 	{
@@ -141,18 +170,30 @@ void GuiFileBrowser::navigateTo(const std::string path)
 		}
 	}
 
-	centerWindow();	
+        centerWindow();
+
+        if (mMenu.size() > 0 && mMenu.getList()->getCursorChangedCallback())
+                mMenu.getList()->getCursorChangedCallback()(CURSOR_STOPPED);
 }
 
 void GuiFileBrowser::centerWindow()
 {
-	if (Renderer::ScreenSettings::fullScreenMenus())
-		mMenu.setSize(Renderer::getScreenWidth(), Renderer::getScreenHeight());
-	else
-	{
-		mMenu.setSize(mMenu.getSize().x(), Renderer::getScreenHeight() * 0.875f);
-		mMenu.setPosition((Renderer::getScreenWidth() - mMenu.getSize().x()) / 2, (Renderer::getScreenHeight() - mMenu.getSize().y()) / 2);
-	}
+        float previewWidth = Renderer::getScreenWidth() * 0.3f;
+        float menuWidth = Renderer::getScreenWidth() - previewWidth;
+
+        if (Renderer::ScreenSettings::fullScreenMenus())
+        {
+                mMenu.setSize(menuWidth, Renderer::getScreenHeight());
+                mMenu.setPosition(0, 0);
+        }
+        else
+        {
+                mMenu.setSize(menuWidth, Renderer::getScreenHeight() * 0.875f);
+                mMenu.setPosition((Renderer::getScreenWidth() - (menuWidth + previewWidth)) / 2, (Renderer::getScreenHeight() - mMenu.getSize().y()) / 2);
+        }
+
+        mPreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
+        mPreview->setMaxSize(previewWidth, mMenu.getSize().y());
 }
 
 bool GuiFileBrowser::input(InputConfig* config, Input input)

--- a/es-app/src/guis/GuiFileBrowser.cpp
+++ b/es-app/src/guis/GuiFileBrowser.cpp
@@ -3,6 +3,8 @@
 #include "ApiSystem.h"
 #include "components/OptionListComponent.h"
 #include "components/ImageComponent.h"
+#include "components/BusyComponent.h"
+#include "resources/TextureResource.h"
 #include "utils/StringUtil.h"
 #include "guis/GuiSettings.h"
 #include "views/ViewController.h"
@@ -10,11 +12,13 @@
 #include "SystemData.h"
 #include "LocaleES.h"
 #include "components/MultiLineMenuEntry.h"
-#include "GuiLoading.h"
 #include "guis/GuiMsgBox.h"
 #include <cstring>
 #include "SystemConf.h"
 #include "Paths.h"
+#include "utils/Platform.h"
+#include "utils/FileSystemUtil.h"
+#include <algorithm>
 
 #define WINDOW_WIDTH (float)Math::max((int)Renderer::getScreenHeight(), (int)(Renderer::getScreenWidth() * 0.65f))
 
@@ -28,7 +32,7 @@
 
 
 GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types, const std::function<void(const std::string&)>& okCallback, const std::string& title)
-	: GuiComponent(window), mMenu(window, title.empty() ? _("FILE BROWSER") : title)
+        : GuiComponent(window), mMenu(window, title.empty() ? _("FILE BROWSER") : title)
 {
 	setTag("popup");
 
@@ -38,9 +42,28 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 
         addChild(&mMenu);
 
-        mPreview = std::make_shared<ImageComponent>(window);
+       mPreview = std::make_shared<ImageComponent>(window);
        mPreview->setVisible(false);
+       mPreview->setAllowFading(false);
        addChild(mPreview.get());
+
+       mLoadingBg = std::make_shared<ImageComponent>(window);
+       mLoadingBg->setVisible(false);
+       mLoadingBg->setImage(":/white.png");
+       mLoadingBg->setColorShift(0x000000FF);
+       addChild(mLoadingBg.get());
+
+       mLoading = std::make_shared<BusyComponent>(window);
+       mLoading->setVisible(false);
+       mLoading->setBackgroundVisible(false);
+       addChild(mLoading.get());
+
+       mCurrentFrame = 0;
+       mFrameTime = 0;
+       mGeneratingPreview = false;
+       mExpectedFrames = 0;
+       mLastFrameCount = 0;
+       mNoFrameTime = 0;
 
        mMenu.getList()->setCursorChangedCallback([this](CursorState state)
        {
@@ -48,6 +71,7 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
                {
                        mPreview->setImage("");
                        mPreview->setVisible(false);
+                       clearVideoPreview();
                        return;
                }
 
@@ -55,11 +79,17 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
                std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(path));
                if (ext == ".jpg" || ext == ".png" || ext == ".gif" || ext == ".svg")
                {
+                       clearVideoPreview();
                        mPreview->setImage(path);
                        mPreview->setVisible(true);
                }
+               else if (ext == ".mp4" || ext == ".avi" || ext == ".mkv" || ext == ".webm")
+               {
+                       generateVideoPreview(path);
+               }
                else
                {
+                       clearVideoPreview();
                        mPreview->setImage("");
                        mPreview->setVisible(false);
                }
@@ -84,7 +114,72 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 		navigateTo(mCurrentPath);
 	}
 	else
-		navigateTo(startPath);
+               navigateTo(startPath);
+}
+
+GuiFileBrowser::~GuiFileBrowser()
+{
+       clearVideoPreview();
+}
+
+void GuiFileBrowser::update(int deltaTime)
+{
+       GuiComponent::update(deltaTime);
+
+       if (mGeneratingPreview)
+       {
+               auto files = Utils::FileSystem::getDirectoryFiles(mTempPreviewDir);
+               files.sort([](const Utils::FileSystem::FileInfo& a, const Utils::FileSystem::FileInfo& b) { return a.path < b.path; });
+
+               for (auto file : files)
+               {
+                       if (file.directory)
+                               continue;
+
+                       if (Utils::String::toLower(Utils::FileSystem::getExtension(file.path)) != ".png")
+                               continue;
+
+                       if (std::find(mVideoFrames.begin(), mVideoFrames.end(), file.path) == mVideoFrames.end())
+                       {
+                               mVideoFrames.push_back(file.path);
+                               // Force-load textures so the preview doesn't flicker on first playthrough
+                               mFrameTextures.push_back(TextureResource::get(file.path, false, true, true));
+                       }
+               }
+
+               if ((int)mVideoFrames.size() >= mExpectedFrames)
+                       mGeneratingPreview = false;
+               else if ((int)mVideoFrames.size() == mLastFrameCount)
+               {
+                       mNoFrameTime += deltaTime;
+                       if (mNoFrameTime > 1000)
+                               mGeneratingPreview = false;
+               }
+               else
+               {
+                       mLastFrameCount = (int)mVideoFrames.size();
+                       mNoFrameTime = 0;
+               }
+       }
+
+       if (!mGeneratingPreview && !mFrameTextures.empty() && !mPreview->isVisible())
+       {
+               mPreview->setImage(mFrameTextures[0]);
+               mPreview->setVisible(true);
+               mLoading->setVisible(false);
+               mLoadingBg->setVisible(false);
+       }
+
+       if (mPreview->isVisible() && !mFrameTextures.empty())
+       {
+               mFrameTime += deltaTime;
+               if (mFrameTime > 100)
+               {
+                       mFrameTime = 0;
+                       mCurrentFrame = (mCurrentFrame + 1) % mFrameTextures.size();
+                       mPreview->setImage(mFrameTextures[mCurrentFrame]);
+               }
+       }
 }
 
 void GuiFileBrowser::navigateTo(const std::string path)
@@ -188,12 +283,70 @@ void GuiFileBrowser::centerWindow()
         }
         else
         {
-                mMenu.setSize(menuWidth, Renderer::getScreenHeight() * 0.875f);
-                mMenu.setPosition((Renderer::getScreenWidth() - (menuWidth + previewWidth)) / 2, (Renderer::getScreenHeight() - mMenu.getSize().y()) / 2);
-        }
+       mMenu.setSize(menuWidth, Renderer::getScreenHeight() * 0.875f);
+       mMenu.setPosition((Renderer::getScreenWidth() - (menuWidth + previewWidth)) / 2, (Renderer::getScreenHeight() - mMenu.getSize().y()) / 2);
+       }
 
-        mPreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
-        mPreview->setMaxSize(previewWidth, mMenu.getSize().y());
+       mPreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
+       mPreview->setMaxSize(previewWidth, mMenu.getSize().y());
+
+       mLoadingBg->setPosition(mPreview->getPosition());
+       mLoadingBg->setSize(previewWidth, mMenu.getSize().y());
+
+       mLoading->setPosition(mPreview->getPosition());
+       mLoading->setSize(previewWidth, mMenu.getSize().y());
+}
+
+void GuiFileBrowser::generateVideoPreview(const std::string& path)
+{
+       clearVideoPreview();
+
+       mTempPreviewDir = Utils::FileSystem::getTempPath() + "/videopreview";
+       Utils::FileSystem::createDirectory(mTempPreviewDir);
+
+       std::string command = "ffmpeg -hide_banner -loglevel error -y -i \"" + path +
+               "\" -t 5 -vf \"fps=10,scale=720:480:force_original_aspect_ratio=decrease\" \"" +
+               mTempPreviewDir + "/frame_%03d.png\"";
+       Utils::Platform::ProcessStartInfo psi(command);
+       psi.waitForExit = false;
+       psi.run();
+
+       mGeneratingPreview = true;
+       mExpectedFrames = 50;
+       mLastFrameCount = 0;
+       mNoFrameTime = 0;
+       mCurrentFrame = 0;
+       mFrameTime = 0;
+       mPreview->setImage("");
+       mPreview->setVisible(false);
+       mLoadingBg->setVisible(true);
+       mLoading->setVisible(true);
+}
+
+void GuiFileBrowser::clearVideoPreview()
+{
+       mGeneratingPreview = false;
+
+#ifndef WIN32
+       Utils::Platform::ProcessStartInfo kill("killall -q ffmpeg");
+       kill.run();
+#endif
+
+       for (auto& img : mVideoFrames)
+               Utils::FileSystem::removeFile(img);
+
+       if (!mTempPreviewDir.empty())
+               Utils::FileSystem::removeDirectory(mTempPreviewDir);
+
+       mVideoFrames.clear();
+       mFrameTextures.clear();
+       mTempPreviewDir.clear();
+       mCurrentFrame = 0;
+       mFrameTime = 0;
+       mLoading->setVisible(false);
+       mLoadingBg->setVisible(false);
+       mLastFrameCount = 0;
+       mNoFrameTime = 0;
 }
 
 bool GuiFileBrowser::input(InputConfig* config, Input input)

--- a/es-app/src/guis/GuiFileBrowser.h
+++ b/es-app/src/guis/GuiFileBrowser.h
@@ -7,6 +7,8 @@
 template<typename T>
 class OptionListComponent;
 
+class ImageComponent;
+
 class GuiFileBrowser : public GuiComponent
 {
 public:
@@ -26,15 +28,16 @@ public:
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
 
 private:
-	void onOk(const std::string& path);
-	void navigateTo(const std::string path);
-	void centerWindow();
+        void onOk(const std::string& path);
+        void navigateTo(const std::string path);
+        void centerWindow();
 
-	MenuComponent mMenu;	
+        MenuComponent mMenu;
 
-	std::string mCurrentPath;
-	std::string mSelectedFile;
-	FileTypes   mTypes;
+        std::string mCurrentPath;
+        std::string mSelectedFile;
+        FileTypes   mTypes;
+        std::shared_ptr<ImageComponent> mPreview;
 
-	std::function<void(const std::string&)> mOkCallback;
+        std::function<void(const std::string&)> mOkCallback;
 };

--- a/es-app/src/guis/GuiFileBrowser.h
+++ b/es-app/src/guis/GuiFileBrowser.h
@@ -7,37 +7,56 @@
 template<typename T>
 class OptionListComponent;
 
+#include <memory>
 class ImageComponent;
+class TextureResource;
+class BusyComponent;
+#include <vector>
 
 class GuiFileBrowser : public GuiComponent
 {
 public:
-	enum FileTypes
-	{
-		IMAGES = 1,
-		MANUALS = 2,
-		VIDEO = 3,
-		DIRECTORY = 4,
-		AUDIO = 5,
-		ALL = 255
-	};
+       enum FileTypes
+       {
+               IMAGES     = 1 << 0,
+               MANUALS    = 1 << 1,
+               VIDEO      = 1 << 2,
+               DIRECTORY  = 1 << 3,
+               AUDIO      = 1 << 4,
+               ALL        = 0xFFFFFFFF
+       };
 
-	GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types = FileTypes::IMAGES, const std::function<void(const std::string&)>& okCallback = nullptr, const std::string& title = "");
+        GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types = FileTypes::IMAGES, const std::function<void(const std::string&)>& okCallback = nullptr, const std::string& title = "");
+        ~GuiFileBrowser() override;
 
-	bool input(InputConfig* config, Input input) override;
-	virtual std::vector<HelpPrompt> getHelpPrompts() override;
+        bool input(InputConfig* config, Input input) override;
+        void update(int deltaTime) override;
+        virtual std::vector<HelpPrompt> getHelpPrompts() override;
 
 private:
         void onOk(const std::string& path);
         void navigateTo(const std::string path);
         void centerWindow();
+        void generateVideoPreview(const std::string& path);
+        void clearVideoPreview();
 
         MenuComponent mMenu;
 
         std::string mCurrentPath;
         std::string mSelectedFile;
-        FileTypes   mTypes;
-        std::shared_ptr<ImageComponent> mPreview;
+       FileTypes   mTypes;
+       std::shared_ptr<ImageComponent> mPreview;
+       std::shared_ptr<BusyComponent> mLoading;
+       std::shared_ptr<ImageComponent> mLoadingBg;
+       std::vector<std::string> mVideoFrames;
+       std::vector<std::shared_ptr<TextureResource>> mFrameTextures;
+        int mCurrentFrame;
+        int mFrameTime;
+        std::string mTempPreviewDir;
+       bool mGeneratingPreview;
+       int mExpectedFrames;
+       int mLastFrameCount;
+       int mNoFrameTime;
 
         std::function<void(const std::string&)> mOkCallback;
 };

--- a/es-app/src/guis/GuiFileBrowser.h
+++ b/es-app/src/guis/GuiFileBrowser.h
@@ -6,13 +6,13 @@
 
 template<typename T>
 class OptionListComponent;
-
+#ifdef _ENABLEEMUELEC
 #include <memory>
 class ImageComponent;
 class TextureResource;
 class BusyComponent;
 #include <vector>
-
+#endif
 class GuiFileBrowser : public GuiComponent
 {
 public:
@@ -25,26 +25,29 @@ public:
                AUDIO      = 1 << 4,
                ALL        = 0xFFFFFFFF
        };
-
         GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types = FileTypes::IMAGES, const std::function<void(const std::string&)>& okCallback = nullptr, const std::string& title = "");
-        ~GuiFileBrowser() override;
-
+#ifdef _ENABLEEMUELEC        
+		~GuiFileBrowser() override;
+#endif
         bool input(InputConfig* config, Input input) override;
+#ifdef _ENABLEEMUELEC
         void update(int deltaTime) override;
+#endif		
         virtual std::vector<HelpPrompt> getHelpPrompts() override;
 
 private:
         void onOk(const std::string& path);
         void navigateTo(const std::string path);
         void centerWindow();
+#ifdef _ENABLEEMUELEC
         void generateVideoPreview(const std::string& path);
         void clearVideoPreview();
-
+#endif
         MenuComponent mMenu;
-
         std::string mCurrentPath;
         std::string mSelectedFile;
        FileTypes   mTypes;
+#ifdef _ENABLEEMUELEC
        std::shared_ptr<ImageComponent> mPreview;
        std::shared_ptr<BusyComponent> mLoading;
        std::shared_ptr<ImageComponent> mLoadingBg;
@@ -57,6 +60,6 @@ private:
        int mExpectedFrames;
        int mLastFrameCount;
        int mNoFrameTime;
-
+#endif
         std::function<void(const std::string&)> mOkCallback;
 };


### PR DESCRIPTION
When browsing for custom loading or exit splash screen videos:

- a miniature version of the selected image is being displayed next to the menu (see screenshot)
- a miniature 5-second animated pre-view of the selected video is being shown next to the menu (see screenshot) 
<img width="1920" height="1080" alt="20250914132853071" src="https://github.com/user-attachments/assets/95ea5625-7dd7-439f-9a5c-278a97b8e0cd" />
<img width="1920" height="1080" alt="20250914132952938" src="https://github.com/user-attachments/assets/7c35c5e0-ea4d-4573-8615-5a5e2f73f1ca" />
