### PR TITLE
EmuELEC - splash configuration fixes 2

### DIFF
--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -345,6 +345,7 @@ std::shared_ptr<OptionListComponent<std::string>> GuiMenu::createSplashLoadingOp
 	splashmode.push_back(_("SHOW STANDARD SPLASH")); // 0
 	splashmode.push_back(_("SHOW CUSTOM SPLASH")); // 1
 	splashmode.push_back(_("SHOW RANDOM SPLASH")); // 2
+	splashmode.push_back(_("USE SCRAPPED MEDIA")); // 3
 
 	std::string str_index = SystemConf::getInstance()->get("ee_splashloading");
 	int index = 0;
@@ -669,8 +670,12 @@ void GuiMenu::openEmuELECSettings()
 	auto splashLoadingOptionList = createSplashLoadingOptionList(mWindow);
 	s->addWithLabel(_("SPLASH LOADING OPTION"), splashLoadingOptionList);
 
+	auto splashLoadingPlatformRoms = std::make_shared<SwitchComponent>(mWindow);
+	splashLoadingPlatformRoms->setState(SystemConf::getInstance()->get("ee_splash_loading_platform_roms") != "0");
+	s->addWithLabel(_("SPLASH LOAD PLATFORMS AND ROMS"), splashLoadingPlatformRoms);
+
 	// File picker for custom splash image
-	s->addFileBrowser(_("CUSTOM SPLASH LOADING"), "ee_customsplash", (GuiFileBrowser::FileTypes) (GuiFileBrowser::FileTypes::IMAGES | GuiFileBrowser::FileTypes::VIDEO));
+	s->addFileBrowser(_("SET CUSTOM SPLASH LOADING MEDIA"), "ee_customsplash", (GuiFileBrowser::FileTypes) (GuiFileBrowser::FileTypes::IMAGES | GuiFileBrowser::FileTypes::VIDEO));
 
 	auto splashLoadingTime = std::make_shared<SliderComponent>(mWindow, 0.f, 100.f, 1.f, "seconds");
 
@@ -685,12 +690,12 @@ void GuiMenu::openEmuELECSettings()
 		SystemConf::getInstance()->set("ee_splash_loading_duration", val);
 	});
 	s->addWithLabel(_("SPLASH LOADING DURATION"), splashLoadingTime);
-	
+
 	auto splashExitOptionList = createSplashExitOptionList(mWindow);
 	s->addWithLabel(_("SPLASH EXIT OPTION"), splashExitOptionList);
 
 	// File picker for custom splash image/video
-	s->addFileBrowser(_("CUSTOM SPLASH EXIT"), "ee_customexitsplash", (GuiFileBrowser::FileTypes) (GuiFileBrowser::FileTypes::IMAGES | GuiFileBrowser::FileTypes::VIDEO));
+	s->addFileBrowser(_("SET CUSTOM SPLASH EXIT MEDIA"), "ee_customexitsplash", (GuiFileBrowser::FileTypes) (GuiFileBrowser::FileTypes::IMAGES | GuiFileBrowser::FileTypes::VIDEO));
 
 	auto splashExitTime = std::make_shared<SliderComponent>(mWindow, 0.f, 100.f, 1.f, "seconds");
 
@@ -707,6 +712,9 @@ void GuiMenu::openEmuELECSettings()
 	s->addWithLabel(_("SPLASH EXIT DURATION"), splashExitTime);
 
 	s->addSaveFunc([=] {
+		if (splashLoadingOptionList->getSelected() == "2") {
+			mWindow->displayNotificationMessage(_U("\uF011  ") + _("PUT RANDOM MEDIA IN '/storage/roms/splash/random'."));
+		}
 		SystemConf::getInstance()->set("ee_splashloading", splashLoadingOptionList->getSelected());
 		SystemConf::getInstance()->set("ee_splashexit", splashExitOptionList->getSelected());
 
@@ -719,6 +727,9 @@ void GuiMenu::openEmuELECSettings()
 
 		SystemConf::getInstance()->set("ee_splash_loading_duration", std::to_string((int)round(splashLoadingTime->getValue())));
 		SystemConf::getInstance()->set("ee_splash_exit_duration", std::to_string((int)round(splashExitTime->getValue())));
+
+		SystemConf::getInstance()->set("ee_splash_loading_platform_roms", splashLoadingPlatformRoms->getState() ? "1" : "0");
+
 		SystemConf::getInstance()->saveSystemConf();
 	});
 


### PR DESCRIPTION
EmuELEC - splash configuration fixes 2.

1. Adds option for scraper splashes to show.
2. SPLASH LOAD PLATFORMS AND ROMS - allows platform and rom splashes to take priority.
3. Custom splash file browser only shows when option is selected. <-- Cannot be done easily so no longer a feature.
4. Message to put splashes in /storage/roms/splash/random if random media splash is selected.

Depends on:
https://github.com/EmuELEC/EmuELEC/pull/1556